### PR TITLE
Fix installer script errors

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -44,10 +44,10 @@ script_exit()
 detect_distro()
 {
     if [ -f /etc/os-release ]; then
-        if [[ $(grep -o -i "amazon_linux:2" | /etc/os-release) ]]; then
+        if [[ $(grep -o -i "amazon_linux:2" /etc/os-release) ]]; then
             DISTRO='rhel'
             VERSION=7
-        elif
+        else
             . /etc/os-release
             DISTRO=$ID
             VERSION=$VERSION_ID


### PR DESCRIPTION
The installation script had two different typo in the lines 47 and 50 from this [PR](https://github.com/microsoft/mdatp-xplat/pull/12)

This is related to this [issue](https://github.com/microsoft/mdatp-xplat/issues/13) 