### PR TITLE
Update schema.json added consumerExperience

### DIFF
--- a/macos/schema/schema.json
+++ b/macos/schema/schema.json
@@ -382,6 +382,20 @@
                         }
                     ],
                     "enum": ["enabled", "disabled"]
+                },
+                "consumerExperience": {
+                    "default": "enabled",
+                    "title": "Control sign-in to consumer version",
+                    "type": "string",
+                    "propertyOrder": 30,
+                    "description": "Specify whether users can sign into the consumer version of Microsoft Defender",
+                    "links": [
+                        {
+                            "href": "https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/mac-preferences#control-sign-in-to-consumer-version-of-microsoft-defender",
+                            "rel": "More information"
+                        }
+                    ],
+                    "enum": ["enabled", "disabled"]
                 }
             }
         },


### PR DESCRIPTION
Added consumerExperience to the scheme.json file because it was missing. It is described in the preference documentation here: https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/mac-preferences?view=o365-worldwide#control-sign-in-to-consumer-version-of-microsoft-defender