### PR TITLE
Add DeviceControl preferences to schema

### DIFF
--- a/macos/schema/schema.json
+++ b/macos/schema/schema.json
@@ -471,6 +471,29 @@
                     "enum": ["disabled", "audit", "block"]
                 }
             }
+        },
+        "deviceControl": {
+            "title": "Device Control",
+            "propertyOrder": 70,
+            "defaultProperties": [],
+            "properties": {
+                "policy": {
+                    "title": "Device Control Policy",
+                    "type": "string",
+                    "propertyOrder": 10,
+                    "description": "JSON string representing the device control policy",
+                    "links": [
+                        {
+                            "href": "https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/mac-device-control-overview?view=o365-worldwide",
+                            "rel": "More information"
+                        },
+                        {
+                            "href": "https://github.com/microsoft/mdatp-devicecontrol/blob/main/Removable%20Storage%20Access%20Control%20Samples/macOS/policy/device_control_policy_schema.json",
+                            "rel": "Schema"
+                        }
+                    ]
+                }
+            }
         }
     }
 }

--- a/macos/settings/data_loss_prevention/com.microsoft.wdav.mobileconfig
+++ b/macos/settings/data_loss_prevention/com.microsoft.wdav.mobileconfig
@@ -58,7 +58,6 @@
                     <key>dataLossPrevention</key>
                     <string>enabled</string>
                 </dict>
-       
             </dict>
         </array>
     </dict>

--- a/macos/settings/data_loss_prevention/schema.json
+++ b/macos/settings/data_loss_prevention/schema.json
@@ -429,6 +429,30 @@
                     "enum": ["enabled", "disabled"]                
                 }
             }
+        },
+        "deviceControl": {
+            "title": "Device Control",
+            "propertyOrder": 60,
+            "defaultProperties": [ "policy" ],
+            "properties": {
+                "policy": {
+                    "title": "Device Control Policy",
+                    "type": "string",
+                    "propertyOrder": 10,
+                    "description": "JSON string representing the device control policy",
+                    "links": [
+                        {
+                            "href": "https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/mac-device-control-overview?view=o365-worldwide",
+                            "rel": "More information"
+                        },
+                        {
+                            "href": "https://github.com/microsoft/mdatp-devicecontrol/blob/main/Removable%20Storage%20Access%20Control%20Samples/macOS/policy/device_control_policy_schema.json",
+                            "rel": "Schema"
+                        }
+                    ]
+                }
+            }
+
         }
     }
 }

--- a/macos/settings/data_loss_prevention/schema.json
+++ b/macos/settings/data_loss_prevention/schema.json
@@ -430,9 +430,24 @@
                 }
             }
         },
+        "tamperProtection": {
+            "title": "Tamper protection",
+            "propertyOrder": 60,
+            "defaultProperties": [],
+            "properties": {
+                "enforcementLevel": {
+                    "title": "Enforcement level",
+                    "default": "audit",
+                    "type": "string",
+                    "propertyOrder": 10,
+                    "description": "Specifies if network protection is disabled, in audit mode, or enforced",
+                    "enum": ["disabled", "audit", "block"]
+                }
+            }
+        },
         "deviceControl": {
             "title": "Device Control",
-            "propertyOrder": 60,
+            "propertyOrder": 70,
             "defaultProperties": [ "policy" ],
             "properties": {
                 "policy": {
@@ -452,7 +467,6 @@
                     ]
                 }
             }
-
         }
     }
 }

--- a/macos/settings/device_control/com.microsoft.wdav.mobileconfig
+++ b/macos/settings/device_control/com.microsoft.wdav.mobileconfig
@@ -58,7 +58,81 @@
                     <key>dataLossPrevention</key>
                     <string>enabled</string>
                 </dict>
-       
+                <key>deviceControl</key>
+                <dict>
+                    <key>policy</key>
+                    <string>{
+    "groups": [
+        {
+            "id": "3f082cd3-f701-4c21-9a6a-ed115c28e217",
+            "name": "All Apple Devices",
+            "query": {
+                "$type": "all",
+                "clauses": [
+                    {
+                        "$type": "primaryId",
+                        "value": "apple_devices"
+                    }
+                ]
+            }
+        }
+    ],
+    "rules": [
+        {
+            "id": "772cef80-229f-48b4-bd17-a6913009298d",
+            "name": "Deny all Apple Devices",
+            "includeGroups": [
+                "3f082cd3-f701-4c21-9a6a-ed115c28e217"
+            ],
+            "entries": [
+                {
+                    "$type": "appleDevice",
+                    "enforcement": {
+                        "$type": "deny"
+                    },
+                    "access": [
+                        "download_files_from_device",
+                        "sync_content_to_device",
+                        "backup_device",
+                        "update_device",
+                        "download_photos_from_device"
+                    ]
+                },
+                {
+                    "$type": "appleDevice",
+                    "enforcement": {
+                        "$type": "auditDeny",
+                        "options": [
+                            "send_event",
+                            "show_notification"
+                        ]
+                    },
+                    "access": [
+                        "download_files_from_device",
+                        "sync_content_to_device",
+                        "backup_device",
+                        "update_device",
+                        "download_photos_from_device"
+                    ]
+                }
+            ]
+        }
+    ],
+    "settings": {
+        "features": {
+            "appleDevice": {
+                "disable": false
+            }
+        },
+        "global": {
+            "defaultEnforcement": "allow"
+        },
+        "ux": {
+            "navigationTarget": "http://www.microsoft.com"
+        }
+    }
+}</string>
+                </dict>
             </dict>
         </array>
     </dict>


### PR DESCRIPTION
Add the DeviceControl feature to the schema.json, and the `policy` preference with links to the mdatp-devicecontrol repo containing the DC policy schema.