### PR TITLE
fix(linux): High cpu parser script

### DIFF
--- a/linux/diagnostic/high_cpu_parser.py
+++ b/linux/diagnostic/high_cpu_parser.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 parser = argparse.ArgumentParser(description="Process scan measures")
-parser.add_argument("--group", type=bool, help="Whether to group the results by process name")
+parser.add_argument("--group", action="store_true", help="Whether to group the results by process name")
 parser.add_argument("--top", type=int, help="Limits the number of results")
 
 args = parser.parse_args()
@@ -17,20 +17,20 @@ if group:
 
     for v in vals:
         name = v["name"]
-        
+
         if "path" in v:
             path = v["path"]
 
         cnt = int(v["total_files_scanned"])
         if name not in groups:
-            groups[name] = { cnt, path }
+            groups[name] = [cnt, path]
         else:
-            groups[name][0] = groups[name] + cnt
+            groups[name][0] = groups[name][0] + cnt
 
     lines = sorted(groups, key=lambda k: groups[k], reverse=True)
     for k in lines[:top]:
-        print("%s\t%d" % (k, groups[k]))
-        
+        print("%s\t%d" % (k, groups[k][0]))
+
 else:
     lines = sorted(vals, key=lambda k: int(k['total_files_scanned']), reverse=True)
     for v in lines[:top]:


### PR DESCRIPTION
Changed groups dictionary values to list instead of set.
Added missing '[0]' to access the count.