### PR TITLE
Allow Linux tagging with spaces

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -855,7 +855,8 @@ set_device_tags()
 
             if [ $tag_exists -eq 0 ]; then
                 # echo "[>] setting tag: ($1, $2)"
-                retry_quietly 2 "mdatp edr tag set --name $1 --value $2" "failed to set tag" $ERR_PARAMETER_SET_FAILED
+                local tag_value="\"${@:2}\""
+                retry_quietly 2 "mdatp edr tag set --name $1 --value $tag_value" "failed to set tag" $ERR_PARAMETER_SET_FAILED
             fi
         else
             script_exit "invalid tag name: $1. supported tags: GROUP, SecurityWorkspaceId, AzureResourceId and SecurityAgentId" $ERR_TAG_NOT_SUPPORTED


### PR DESCRIPTION
Fixes #19 

When attempting to include tags with spaces, the tag was truncated after the first space. E.g.

```
-t GROUP "Tag with spaces"
```

Would result in a tag key value of `GROUP Tag`.

This is due to the way the `${tags[@]}"` expression handles a space delimited array as passed.

The fix gathers ALL arguments after the "key" and builds a quoted string to pass to the eventual command.