### PR TITLE
Fix typo in linux/MDEAuditdAnalyzer/Readme

### DIFF
--- a/linux/LinuxMDEparser/README.MD
+++ b/linux/LinuxMDEparser/README.MD
@@ -47,7 +47,6 @@ Argparse - https://pypi.org/project/argparse/ --> `pip install argparse`
 # Compiling tool using pyinstaller
 `
     pip install pyinstaller
-
     pyinstaller -F -n LinuxMDEparser
 `
 

--- a/linux/LinuxMDEparser/README.MD
+++ b/linux/LinuxMDEparser/README.MD
@@ -15,7 +15,7 @@ EX:
 
 Make sure you run it from the folder where the log file is located. Excel file will also be created in the same folder.
 
-Files are included when you collect the Linux - "mdatp diagnostic create" command in Linux, except for real_time_protection.json - this ones need to be collected locally in a terminal window:
+Files are included when you collect the Linux - "mdatp diagnostic create" command in Linux, except for real_time_protection.json - this one needs to be collected locally in a terminal window:
 
 `mdatp diagnostic real-time-protection-statistics --output json > real_time_protection.json`
 

--- a/linux/LinuxMDEparser/README.MD
+++ b/linux/LinuxMDEparser/README.MD
@@ -2,24 +2,30 @@
 Microsoft Defender Endpoint Log Parser for Linux.
 
 # About
-The LinuxMDEparser is a tool that allows you to export or parse MDE for Linux log files to Excel, making it easier to filter and search the logs. After collecting the MDE logs from any Linux machine, you can then run this tool on your on Windows.
+The LinuxMDEparser is a tool that allows you to export or parse MDE for Linux log files to Excel, making it easier to filter and search the logs. After collecting the MDE logs from any Linux machine, you can then run this tool on your Windows/Linux machine.
 
 # Usage
 python3 main.py {Command} <option>
 
-EX: python3 main.py real-time-protection --convert
+EX: 
+
+`
+    python3 main.py real-time-protection --convert
     python3 main.py wdavhistory -h
+`
 
 Make sure you run it from the folder where the log file is located. Excel file will also be created in the same folder.
 
 Files are included when you collect the Linux - "mdatp diagnostic create" command in Linux, except for real_time_protection.json - this ones need to be collected locally in a terminal window:
 
+`
 mdatp diagnostic real-time-protection-statistics --output json > real_time_protection.json
+`
 
 More details https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/linux-support-perf
 
 # Help
-You can always check the available options by running: LinuxMDEparser -h
+You can always check the available options by running: `LinuxMDEparser -h`
 
 usage: LinuxMDEparser [command] [--option]
 
@@ -33,19 +39,21 @@ Commands:
     real-time-protection
                         Troubleshoot performance issues for Microsoft Defender
 
-# Dependecies
-LinuxMDEparser will require you to install the following dependecies:
+# Dependencies
+LinuxMDEparser will require you to install the following dependencies:
 
-Argparse - https://pypi.org/project/argparse/ --> pip install argparse
+Argparse - https://pypi.org/project/argparse/ --> `pip install argparse`
 
 # Compiling tool using pyinstaller
-pip install pyinstaller
+`
+    pip install pyinstaller
 
-pyinstaller -F -n LinuxMDEparser
+    pyinstaller -F -n LinuxMDEparser
+`
 
 pyinstaller produces a standalone executable as dist/LinuxMDEparser.exe
 
 For a compilied version of the latest release, please check "dist" folder or https://aka.ms/LinuxMDEparser
 
 # To-Do
-Allow for special caracters such as Chinese
+Allow for special characters such as Chinese

--- a/linux/LinuxMDEparser/README.MD
+++ b/linux/LinuxMDEparser/README.MD
@@ -9,18 +9,15 @@ python3 main.py {Command} <option>
 
 EX: 
 
-`
-    python3 main.py real-time-protection --convert
-    python3 main.py wdavhistory -h
-`
+`python3 main.py real-time-protection --convert`
+
+`python3 main.py wdavhistory -h`
 
 Make sure you run it from the folder where the log file is located. Excel file will also be created in the same folder.
 
 Files are included when you collect the Linux - "mdatp diagnostic create" command in Linux, except for real_time_protection.json - this ones need to be collected locally in a terminal window:
 
-`
-mdatp diagnostic real-time-protection-statistics --output json > real_time_protection.json
-`
+`mdatp diagnostic real-time-protection-statistics --output json > real_time_protection.json`
 
 More details https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/linux-support-perf
 
@@ -45,10 +42,10 @@ LinuxMDEparser will require you to install the following dependencies:
 Argparse - https://pypi.org/project/argparse/ --> `pip install argparse`
 
 # Compiling tool using pyinstaller
-`
-    pip install pyinstaller
-    pyinstaller -F -n LinuxMDEparser
-`
+    
+`pip install pyinstaller`
+
+`pyinstaller -F -n LinuxMDEparser`
 
 pyinstaller produces a standalone executable as dist/LinuxMDEparser.exe
 

--- a/linux/MDEAuditdAnalyzer/README.md
+++ b/linux/MDEAuditdAnalyzer/README.md
@@ -26,7 +26,11 @@ pip install -r requirements.txt
 
 python MDEAuditAnalyzer.py
 
-# Dependecies
-Dependecies can be found on the requirements.txt
+# Dependencies
+Dependencies can be found in requirements.txt
 
-Manual install - pip install pandas
+Manual install:
+
+`
+    pip install pandas
+`


### PR DESCRIPTION
Before this change:

-  There was a minor typo in the README.md file in linux/MDEAuditdAnalyzer

After this change:
- There are no longer any typos in the mentioned file