### PR TITLE
Do not log STDERR and extend sleep for license chk

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -12,7 +12,7 @@
 #
 #============================================================================
 
-SCRIPT_VERSION="0.5.9"
+SCRIPT_VERSION="0.5.10"
 ASSUMEYES=
 CHANNEL=insiders-fast
 DISTRO=
@@ -790,7 +790,7 @@ onboard_device()
 
     if [[ $ONBOARDING_SCRIPT == *.py ]]; then
         # Make sure python is installed
-        PYTHON=$(which python || which python3)
+        PYTHON=$(which python  2>&- || which python3  2>&-)
 
         if [ -z $PYTHON ]; then
             script_exit "error: cound not locate python." $ERR_FAILED_DEPENDENCY
@@ -809,7 +809,7 @@ onboard_device()
     fi
 
     # validate onboarding
-    sleep 3
+    sleep 120
     if [[ $(mdatp health --field org_id | grep "No license found" -c) -gt 0 ]]; then
         script_exit "onboarding failed" $ERR_ONBOARDING_FAILED
     fi

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -820,6 +820,7 @@ onboard_device()
             license_found=false
         else
         # If "No license found" is not present, exit the loop
+            license_found=true
             break
         fi
     done

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -790,7 +790,7 @@ onboard_device()
 
     if [[ $ONBOARDING_SCRIPT == *.py ]]; then
         # Make sure python is installed
-        PYTHON=$(which python  2>&- || which python3  2>&-)
+        PYTHON=$(which python 2>/dev/null || which python3 2>/dev/null)
 
         if [ -z $PYTHON ]; then
             script_exit "error: cound not locate python." $ERR_FAILED_DEPENDENCY
@@ -809,10 +809,25 @@ onboard_device()
     fi
 
     # validate onboarding
-    sleep 120
-    if [[ $(mdatp health --field org_id | grep "No license found" -c) -gt 0 ]]; then
+    license_found=false
+    
+    for ((i = 1; i <= 10; i++)); do
+        sleep 15 # Delay for 15 seconds before checking the license status
+        
+        # Check if "No license found" is present in the output of the mdatp health command
+        if [[ $(mdatp health --field org_id | grep "No license found" -c) -gt 0 ]]; then
+        # If "No license found" is present, set the license_found variable to false
+            license_found=false
+        else
+        # If "No license found" is not present, exit the loop
+            break
+        fi
+    done
+    
+    if [[ $license_found == false ]]; then
         script_exit "onboarding failed" $ERR_ONBOARDING_FAILED
     fi
+    
     log_info "[v] onboarded"
 }
 


### PR DESCRIPTION
This PR introduces two small changes.

- Send STDERR to /dev/null in the onboard_device() function. On some operating systems, the check for installed python version (which python || which python3) will produce a STDERR message that is captured in the MDE.Linux extension log when installing via VM or connected machine extension.

Example:
2022-11-29 20:32:26,649, ERROR - MDE process stdout: b'--- mde_installer.sh v0.5.9 ---\n[>] detected: mariner 2.0  (mariner)\n[>] scaled: 2.0\n[v] set package manager: yum\n[>] onboarding script: onboardingScript.tmp.py\nwhich: **no python in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin)\n**[S]

- Extend sleep time between completion of onboarding_script and mdatp health check to 120 seconds. In some scenarios, the 3 second sleep is not enough time for an agent to reflect a successfully on-boarded status. The short validation window may create false failed on-boarding logs and extension status propagation as the agent may achieve a healthy status after the 3 seconds.

Example:
MDE installed.\n[S] Version: ATTENTION: No license found. Contact your administrator for help.\n"101.85.27"\n[S] Onboarded: ATTENTION: No license found. Contact your administrator for help.\nfalse\n[S] Passive mode: ATTENTION: No license found. Contact your administrator for help.\nfalse\n[S] Device tags: ATTENTION: No license found. Contact your administrator for help.\n[]\n[S] Subsystem: ATTENTION: No license found. Contact your administrator for help.\n"fanotify"\n[S] Conflicting applications: ATTENTION: No license found. Contact your administrator for help.\n[]\n[x] onboarding failed\n[*] exiting (31)\n' (agent was in a healthy status, but the extension showed a failed install in the Azure portal).