### PR TITLE
Add DLP cloud egress example settings

### DIFF
--- a/macos/settings/data_loss_prevention/cloud_egress/README.md
+++ b/macos/settings/data_loss_prevention/cloud_egress/README.md
@@ -1,0 +1,20 @@
+# Cloud Egress Examples
+
+If you want to restrict the CloudEgress to browser, please set following in your com.microsoft.wdav.mobileconfig:
+
+```xml
+<key>dlp</key>
+<dict>
+	<key>features</key>
+	<array>
+		<dict>
+			<key>name</key>
+			<string>DLP_browser_only_cloud_egress</string>
+			<key>state</key>
+			<string>enabled</string>
+		</dict>
+	</array>
+</dict>
+```
+
+You can also take a look at the sample file: [com.microsoft.wdav.mobileconfig](./com.microsoft.wdav.mobileconfig)

--- a/macos/settings/data_loss_prevention/cloud_egress/com.microsoft.wdav.mobileconfig
+++ b/macos/settings/data_loss_prevention/cloud_egress/com.microsoft.wdav.mobileconfig
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1">
+    <dict>
+        <key>PayloadUUID</key>
+        <string>C4E6A782-0C8D-44AB-A025-EB893987A295</string>
+        <key>PayloadType</key>
+        <string>Configuration</string>
+        <key>PayloadOrganization</key>
+        <string>Microsoft</string>
+        <key>PayloadIdentifier</key>
+        <string>com.microsoft.wdav</string>
+        <key>PayloadDisplayName</key>
+        <string>Microsoft Defender for Endpoint settings</string>
+        <key>PayloadDescription</key>
+        <string>Microsoft Defender for Endpoint configuration settings</string>
+        <key>PayloadVersion</key>
+        <integer>1</integer>
+        <key>PayloadEnabled</key>
+        <true/>
+        <key>PayloadRemovalDisallowed</key>
+        <true/>
+        <key>PayloadScope</key>
+        <string>System</string>
+        <key>PayloadContent</key>
+        <array>
+            <dict>
+                <key>PayloadUUID</key>
+                <string>99DBC2BC-3B3A-46A2-A413-C8F9BB9A7295</string>
+                <key>PayloadType</key>
+                <string>com.microsoft.wdav</string>
+                <key>PayloadOrganization</key>
+                <string>Microsoft</string>
+                <key>PayloadIdentifier</key>
+                <string>com.microsoft.wdav</string>
+                <key>PayloadDisplayName</key>
+                <string>Microsoft Defender for Endpoint configuration settings</string>
+                <key>PayloadDescription</key>
+                <string/>
+                <key>PayloadVersion</key>
+                <integer>1</integer>
+                <key>PayloadEnabled</key>
+                <true/>
+                <key>antivirusEngine</key>
+                <dict>
+                    <key>passiveMode</key>
+                    <true/>
+                </dict>
+                <key>cloudService</key>
+                <dict>
+                    <key>diagnosticLevel</key>
+                    <string>optional</string>
+                </dict>
+                <key>features</key>
+                <dict>
+                    <key>systemExtensions</key>
+                    <string>enabled</string>
+                    <key>dataLossPrevention</key>
+                    <string>enabled</string>
+                </dict>
+                <key>dlp</key>
+                <dict>
+                    <key>features</key>
+                    <array>
+                        <dict>
+                            <key>name</key>
+                            <string>DLP_browser_only_cloud_egress</string>
+                            <key>state</key>
+                            <string>enabled</string>
+                        </dict>
+                    </array>
+                </dict>
+            </dict>
+        </array>
+    </dict>
+</plist>


### PR DESCRIPTION
Add a new example for DLP settings that demonstrates how to use the `dlp/features` configuration area to enable the `DLP_browser_only_cloud_egress` feature.