### PR TITLE
Changed total_files_scanned from underscore to camelcase

### DIFF
--- a/linux/diagnostic/high_cpu_parser.py
+++ b/linux/diagnostic/high_cpu_parser.py
@@ -21,7 +21,7 @@ if group:
         if "path" in v:
             path = v["path"]
 
-        cnt = int(v["total_files_scanned"])
+        cnt = int(v["totalFilesScanned"])
         if name not in groups:
             groups[name] = [cnt, path]
         else:
@@ -32,7 +32,7 @@ if group:
         print("%s\t%d" % (k, groups[k][0]))
 
 else:
-    lines = sorted(vals, key=lambda k: int(k['total_files_scanned']), reverse=True)
+    lines = sorted(vals, key=lambda k: int(k['totalFilesScanned']), reverse=True)
     for v in lines[:top]:
-        if int(v["total_files_scanned"]) != 0:
-            print("%s\t%s\t%s\t%s" % (v["id"], v["name"], v["total_files_scanned"], v["path"]))
+        if int(v["totalFilesScanned"]) != 0:
+            print("%s\t%s\t%s\t%s" % (v["id"], v["name"], v["totalFilesScanned"], v["path"]))


### PR DESCRIPTION
Fix for error:
`KeyError: 'total_files_scanned' `

real-time-protection-statistics have changed the json output from underscore to camelcase for total files scanned.
`mdatp diagnostic real-time-protection-statistics --output json`
Example:
```
        {
            "id": 1,
            "isActive": true,
            "maxFileScanTime": "0",
            "name": "systemd",
            "path": "/usr/lib/systemd/systemd",
            "resourceScanTime": "0",
            "scannedFilePaths": null,
            "totalEventsSent": "0",
            "totalFilesScanned": "0",
            "totalScanTime": "0"
        },
```

Tested on Ubuntu 22.04 
mdatp version:
Product version: 101.23052.0009