### PR TITLE
Add quiet option to yum repolist command

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -621,7 +621,7 @@ install_on_fedora()
     fi
 
     # Configure repository if it does not exist
-    yum repolist $repo-$CHANNEL | grep "$repo-$CHANNEL"
+    yum -q repolist $repo-$CHANNEL | grep "$repo-$CHANNEL"
     found_repo=$?
     if [ $found_repo -eq 0 ]; then
         log_info "[i] repository already configured"
@@ -707,7 +707,7 @@ remove_repo()
         fi
 
         local repo_name="$repo-$CHANNEL"
-        yum repolist $repo_name | grep "$repo_name" &> /dev/null
+        yum -q repolist $repo_name | grep "$repo_name" &> /dev/null
         if [ $? -eq 0 ]; then
             run_quietly "yum-config-manager --disable $repo_name" "Unable to disable the repo ($?)" $ERR_FAILED_REPO_CLEANUP
             run_quietly "find /etc/yum.repos.d -exec grep -lqR \"\[$repo_name\]\" '{}' \; -delete" "Unable to remove repo ($?)" $ERR_FAILED_REPO_CLEANUP


### PR DESCRIPTION
### **Issue with current script:**
Currently, script checks for existing configured repos in yum via yum repolist. Currently, repolist check always gives repository as configured even when not configured. This is because of following reason: yum repolist command by default also notifies about the current state or actions of DNF in output. So, that output will be captured in grep. e.g. I issued following command in rhel 8.7, and got this result.
> sudo yum repolist nonexistingrepo | grep nonexistingrepo; echo "result=$?"
Command: yum repolist nonexistingrepo
Extra commands: ['repolist', 'nonexistingrepo']
Last metadata expiration check: 0:02:35 ago on Mon 24 Jul 2023 05:55:51 AM UTC. result=0

### **How this change addresses the problem mentioned above:**
Added -q option in yum repolist command so that it shows just the relevant content and suppresses messages notifying about the current state or actions of DNF.