### PR TITLE
Fix high_cpu_parser.py (looking for wrong key)

### DIFF
--- a/linux/diagnostic/high_cpu_parser.py
+++ b/linux/diagnostic/high_cpu_parser.py
@@ -21,7 +21,7 @@ if group:
         if "path" in v:
             path = v["path"]
 
-        cnt = int(v["total_files_scanned"])
+        cnt = int(v["totalFilesScanned"])
         if name not in groups:
             groups[name] = [cnt, path]
         else:
@@ -32,7 +32,7 @@ if group:
         print("%s\t%d" % (k, groups[k][0]))
 
 else:
-    lines = sorted(vals, key=lambda k: int(k['total_files_scanned']), reverse=True)
+    lines = sorted(vals, key=lambda k: int(k['totalFilesScanned']), reverse=True)
     for v in lines[:top]:
-        if int(v["total_files_scanned"]) != 0:
-            print("%s\t%s\t%s\t%s" % (v["id"], v["name"], v["total_files_scanned"], v["path"]))
+        if int(v["totalFilesScanned"]) != 0:
+            print("%s\t%s\t%s\t%s" % (v["id"], v["name"], v["totalFilesScanned"], v["path"]))


### PR DESCRIPTION
This script is currently broken with the newest version of mdatp. It throws this error:

Traceback (most recent call last):
  File "C:\Users\<user>\mde-analyzer\high_cpu_parser_old.py", line 35, in <module>
    lines = sorted(vals, key=lambda k: int(k['total_files_scanned']), reverse=True)
  File "C:\Users\<user>\mde-analyzer\high_cpu_parser_old.py", line 35, in <lambda>
    lines = sorted(vals, key=lambda k: int(k['total_files_scanned']), reverse=True)
KeyError: 'total_files_scanned'

The output from the diagnostics function of mdatp returns data formatted as such:

{"id":807,"isActive":true,"maxFileScanTime":"0","name":"networkd-dispat","path":"/usr/bin/python3.10","resourceScanTime":"0","scannedFilePaths":null,"totalEventsSent":"0","totalFilesScanned":"0","totalScanTime":"0"}

The python script looks for the key 'total_files_scanned' while the output returns it in camelCase, it seems that the agent was changed but in any case, the script can be fixed by changing the total_files_scanned to totalFilesScanned