### PR TITLE
Issue faced on Amazon Linux 2023 during mde installtion script with p…

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -600,7 +600,13 @@ install_on_fedora()
         return
     fi
 
-    packages=(curl yum-utils)
+    # curl-minimal results into issues when present and trying to install curl, so skip installing
+    # the curl over Amazon Linux 2023
+    if [[ "$VERSION" == "2023" ]] && [[ "$DISTRO" == "amzn" ]] && $(check_if_pkg_is_installed curl-minimal); then
+        packages=(yum-utils)
+    else
+        packages=(curl yum-utils)
+    fi
 
     if [[ $SCALED_VERSION == 7* ]] && [ "$DISTRO" == "rhel" ]; then
         packages=($packages deltarpm)


### PR DESCRIPTION
** Amazon Linux 2023 has curl-minimal installed, mde-installer script internally installs curl which conflicts with the existing installation of curl-minimal and exits.  So have placed check in the installer for Amazon Linux 2023 which checks for the curl-minimal, if it exists then skips installing the curl package.  