### PR TITLE
updated mde_installer script in case of mariner distro

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -12,7 +12,7 @@
 #
 #============================================================================
 
-SCRIPT_VERSION="0.6.6"
+SCRIPT_VERSION="0.6.7"
 ASSUMEYES=-y
 CHANNEL=
 DISTRO=
@@ -576,12 +576,22 @@ install_on_mariner()
         return
     fi
 
-    ### Add Preview Repo File ###
-    tdnf -y install mariner-repos-extras-preview
+    # To use config-manager plugin, install dnf-plugins-core package
+    run_quietly "$PKG_MGR_INVOKER install dnf-plugins-core" "failed to install dnf-plugins-core"
 
     ### Install MDE ###
     log_info "[>] installing MDE"
-    run_quietly "$PKG_MGR_INVOKER install mdatp" "unable to install MDE ($?)" $ERR_INSTALLATION_FAILED
+    if [ "$CHANNEL" = "prod" ]; then
+        run_quietly "$PKG_MGR_INVOKER install mariner-repos-extras" "unable to install mariner-repos-extras"
+        run_quietly "$PKG_MGR_INVOKER config-manager --enable mariner-official-extras" "unable to enable extras repo"
+        run_quietly "$PKG_MGR_INVOKER config-manager --disable mariner-official-extras-preview" "unable to disable extras-preview repo"
+        run_quietly "$PKG_MGR_INVOKER install mdatp" "unable to install MDE ($?)" $ERR_INSTALLATION_FAILED
+    else
+        ### Add Preview Repo File ###
+        run_quietly "$PKG_MGR_INVOKER install mariner-repos-extras-preview" "unable to install mariner-repos-extras-preview"
+        run_quietly "$PKG_MGR_INVOKER config-manager --enable mariner-official-extras-preview" "unable to enable extras-preview repo"
+        run_quietly "$PKG_MGR_INVOKER install mdatp" "unable to install MDE ($?)" $ERR_INSTALLATION_FAILED
+    fi
 
     sleep 5
     log_info "[v] installed"


### PR DESCRIPTION
In case of the mariner vm, running the installer script automatically configures the preview-repo to install mdatp, which inturn affects the mariner vm, because its starts to get preview-repo versions of other packages too while updating.

With my change it is made sure in case of mariner distro, mde installation from extras-preview repo happens only when no channel is specified in the installer script. If the installer script is run with prod channel as option then it tries to get mdatp from the extras repo.(mdatp not available here as of now, so installation expected to fail).