### PR TITLE
Fixing installer script for CentOS-8

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -12,7 +12,7 @@
 #
 #============================================================================
 
-SCRIPT_VERSION="0.6.7"
+SCRIPT_VERSION="0.6.8"
 ASSUMEYES=-y
 CHANNEL=
 DISTRO=
@@ -827,11 +827,7 @@ scale_version_id()
         elif [[ $VERSION == 7* ]] || [ "$DISTRO" == "amzn" ]; then
             SCALED_VERSION=7
         elif [[ $VERSION == 8* ]] || [ "$DISTRO" == "fedora" ]; then
-            if [[ $DISTRO == "almalinux" || $DISTRO == "rocky" ]]; then
-                SCALED_VERSION=8
-            else
-                SCALED_VERSION=8.0
-            fi
+            SCALED_VERSION=8
         elif [[ $VERSION == 9* ]]; then
             if [[ $DISTRO == "almalinux" || $DISTRO == "rocky" ]]; then
                 SCALED_VERSION=9


### PR DESCRIPTION
Installation using the mde_installer.sh script is failing for CentOS 8. Here's the error when trying to add repo.

Status code: 404 for https://packages.microsoft.com/config/centos/8.0/prod.repo (IP: 13.107.213.67)
Error: Configuration of repo failed
The right url is supposed to be https://packages.microsoft.com/config/centos/8/prod.repo. Thus scaled version 8.0 needs to be fixed to 8.