### PR TITLE
Macos schema update schedule scan

### DIFF
--- a/macos/schema/schema.json
+++ b/macos/schema/schema.json
@@ -697,6 +697,98 @@
                     }
                 }
             }
+        },
+        "scheduledScan": {
+            "title": "ScheduledScan",
+            "propertyOrder": 100,
+            "defaultProperties": [],
+            "properties": {
+                "ignoreExclusions": {
+                    "title": "ignoreExclusions",
+                    "description": "ignoreExclusions",
+                    "propertyOrder": 10,
+                    "type": "boolean",
+                    "default": "false"
+                },
+                "lowPriorityScheduledScan":{
+                    "title": "lowPriorityScheduledScan",
+                    "description": "lowPriorityScheduledScan",
+                    "propertyOrder": 20,
+                    "type": "boolean",
+                    "default": "false"
+                },
+                "dailyConfiguration":{
+                    "title": "dailyConfiguration",
+                    "propertyOrder": 30,
+                    "defaultProperties": [],
+                    "properties": {
+                        "timeOfDay":{
+                            "title": "timeOfDay",
+                            "description": "Specifies the time of day, as the number of minutes after midnight, to perform a scheduled scan.",
+                            "propertyOrder": 10,
+                            "type": "integer",
+                            "default": "0"
+                        },
+                        "interval":{
+                            "title": "interval",
+                            "description": "0 (never), every 1 (hour) to 24 (hours, 1 scan per day)",
+                            "propertyOrder": 30,
+                            "type": "integer",
+                            "default": "0"
+                        },
+                        "randomizeScanStartTime":{
+                            "title": "randomizeScanStartTime",
+                            "description": "Only applicable for daily quick scans or weekly quick/full scans. Randomize the start time of the scan by up to specified number of hours.",
+                            "propertyOrder": 40,
+                            "type": "integer",
+                            "default": "0"
+                        }
+                    }
+                },
+                "weeklyConfiguration":{
+                    "title": "weeklyConfiguration",
+                    "propertyOrder": 40,
+                    "defaultProperties": [],
+                    "properties": {
+                        "dayOfWeek":{
+                            "title": "dayOfWeek",
+                            "description": "The range is between 0 and 8. 0:Everyday, 1-7:Sunday to Saturday, 8:Never",
+                            "propertyOrder": 10,
+                            "type": "integer",
+                            "default": "8"
+                        },
+                        "timeOfDay":{
+                            "title": "timeOfDay",
+                            "description": "Specifies the time of day, as the number of minutes after midnight, to perform a scheduled scan.",
+                            "propertyOrder": 20,
+                            "type": "integer",
+                            "default": "0"
+                        },
+                        "scanType":{
+                            "title": "scanType",
+                            "description": "quick or full.",
+                            "propertyOrder": 30,
+                            "type": "string",
+                            "default": "quick",
+                            "enum": ["quick", "full"]
+                        },
+                        "interval":{
+                            "title": "interval",
+                            "description": "0 (never), every 1 (hour) to 24 (hours, 1 scan per day)",
+                            "propertyOrder": 40,
+                            "type": "integer",
+                            "default": "0"
+                        },
+                        "randomizeScanStartTime":{
+                            "title": "randomizeScanStartTime",
+                            "description": "Only applicable for daily quick scans or weekly quick/full scans. Randomize the start time of the scan by up to specified number of hours.",
+                            "propertyOrder": 50,
+                            "type": "integer",
+                            "default": "0"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/macos/schema/schema.json
+++ b/macos/schema/schema.json
@@ -520,6 +520,20 @@
                         }
                     ],
                     "enum": ["enabled", "disabled"]                
+                },
+                "scheduledScan":{
+                    "default": "disabled",
+                    "title": "Scheduled Scan",
+                    "type": "string",
+                    "propertyOrder": 30,
+                    "description": "Schedule scans with Microsoft Defender for Endpoint.",
+                    "links": [
+                        {
+                            "href": "https://learn.microsoft.com/en-us/defender-endpoint/mac-schedule-scan",
+                            "rel": "More information"
+                        }
+                    ],
+                    "enum": ["enabled", "disabled"]   
                 }
             }
         },


### PR DESCRIPTION
The Defender periodic scan is a separate article from the MDE settings in the documentation, but the Domain is the same at com.microsoft.wdav, so some people may not be aware of it and may not have set it up correctly.

https://learn.microsoft.com/en-us/defender-endpoint/mac-jamfpro-policies
https://learn.microsoft.com/en-us/defender-endpoint/mac-schedule-scan

I think it would be more helpful to IT administrators to be able to use a centralized schema for management in Jamf Pro.

thanks