### PR TITLE
changing apt-key method of adding key by gpg --dearmor 

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -544,8 +544,8 @@ install_on_debian()
     run_quietly "curl -s -o microsoft.list $PMC_URL/$DISTRO/$SCALED_VERSION/$CHANNEL.list" "unable to fetch repo list" $ERR_FAILED_REPO_SETUP
     run_quietly "mv ./microsoft.list /etc/apt/sources.list.d/microsoft-$CHANNEL.list" "unable to copy repo to location" $ERR_FAILED_REPO_SETUP
 
-    ### Fetch the gpg key ###
-    run_quietly "curl -s https://packages.microsoft.com/keys/microsoft.asc | apt-key add -" "unable to fetch the gpg key" $ERR_FAILED_REPO_SETUP
+    # Fetch and add GPG key using gpg
+    run_quietly "curl -s https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft.gpg" "unable to fetch the gpg key" $ERR_FAILED_REPO_SETUP
     run_quietly "apt-get update" "[!] unable to refresh the repos properly"
 
     ### Install MDE ###


### PR DESCRIPTION
since ap-key has been deprecated: 

### Manpages Evidence
https://manpages.debian.org/testing/apt/aptkey.8.en.html#:~:text=Use%20of%20apt,and%20Ubuntu%2022.04.
### Debian Release Notes
https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#deprecated-components:~:text=bullseye%20is%20the%20final%20Debian%20release%20to%20ship%20apt%2Dkey.%20Keys%20should%20be%20managed%20by%20dropping%20files%20into%20/etc/apt/trusted.gpg.d%20instead%2C%20in%20binary%20format%20as%20created%20by%20gpg%20%2D%2Dexport%20with%20a%20.gpg%20extension%2C%20or%20ASCII%20armored%20with%20a%20.asc%20extension.

So we should not be using apt-key we already have some support cases running into this issue.