### PR TITLE
Updated offline definition downloader script to include Arm64 Linux package

### DIFF
--- a/linux/definition_downloader/xplat_offline_updates_download.ps1
+++ b/linux/definition_downloader/xplat_offline_updates_download.ps1
@@ -215,13 +215,9 @@ Function Invoke-Download-All-Updates([string]$platform, [bool]$downloadPreviewUp
             {
                 New-Item -ItemType Directory -Path $path
             }
-            if (($platform -eq "linux") -and ($arch -eq "arm64"))
-            {
-                continue # currently, we do not support linux arm64, so we skip the download step in this case
-            }
             $linkid = Get-Link-Id $platform
             $url = $baseUpdateUrl + "?linkid=$linkid"
-            if (($platform -eq "mac") -and ($arch -eq "arm64"))
+            if ($arch -eq "arm64")
             {
                 $url = $url + $armArchArgs
             }

--- a/linux/definition_downloader/xplat_offline_updates_download.ps1
+++ b/linux/definition_downloader/xplat_offline_updates_download.ps1
@@ -37,8 +37,13 @@
         │   │   ├── manifest.json
         │   │   └── updates.zip
         │   ├── arch_arm64
+        │   │   ├── manifest.json
+        │   │   └── updates.zip
         ├── preview_back
         │   ├── arch_x86_64
+        │   │   ├── manifest.json
+        │   │   └── updates.zip
+        │   ├── arch_arm64
         │   │   ├── manifest.json
         │   │   └── updates.zip
         ├── production
@@ -46,10 +51,15 @@
         │   │   ├── manifest.json
         │   │   └── updates.zip
         │   ├── arch_arm64
+        │   │   ├── manifest.json
+        │   │   └── updates.zip
         └── production_back
             ├── arch_x86_64
             │   ├── manifest.json
             │   └── updates.zip 
+            └── arch_arm64
+                ├── manifest.json
+                └── updates.zip
 #>
 
 $scriptVersion = "0.0.2"

--- a/linux/definition_downloader/xplat_offline_updates_download.sh
+++ b/linux/definition_downloader/xplat_offline_updates_download.sh
@@ -35,8 +35,13 @@
 #       │   │   ├── manifest.json
 #       │   │   └── updates.zip
 #       │   ├── arch_arm64
+#       │   │   ├── manifest.json
+#       │   │   └── updates.zip
 #       ├── preview_back
 #       │   ├── arch_x86_64
+#       │   │   ├── manifest.json
+#       │   │   └── updates.zip
+#       │   ├── arch_arm64
 #       │   │   ├── manifest.json
 #       │   │   └── updates.zip
 #       ├── production
@@ -44,10 +49,15 @@
 #       │   │   ├── manifest.json
 #       │   │   └── updates.zip
 #       │   ├── arch_arm64
+#       │   │   ├── manifest.json
+#       │   │   └── updates.zip
 #       └── production_back
 #           ├── arch_x86_64
 #           │   ├── manifest.json
 #           │   └── updates.zip
+#           └── arch_arm64
+#               ├── manifest.json
+#               └── updates.zip
 
 scriptVersion="0.0.2"
 defaultBaseUpdateUrl="https://go.microsoft.com/fwlink/"

--- a/linux/definition_downloader/xplat_offline_updates_download.sh
+++ b/linux/definition_downloader/xplat_offline_updates_download.sh
@@ -198,14 +198,10 @@ function invoke_download_all_updates()
                 mkdir -p "$path"
             fi
             
-            if [[ ( "$platform" == "linux" ) && ( "$arch" == "arm64" ) ]]; then
-                continue  # Currently, we do not support Linux ARM64, so we skip the download step in this case.
-            fi
-            
             linkid=$(get_link_id "$platform")
             url="$baseUpdateUrl?linkid=$linkid"
             
-            if [[ ( "$platform" == "mac" ) && ( "$arch" == "arm64" ) ]]; then
+            if [[ "$arch" == "arm64" ]]; then
                 url="$url$armArchArgs"
             fi
             


### PR DESCRIPTION
## Description
Updating downloader script `xplat_offline_updates_download.ps1` & `xplat_offline_updates_download.sh` to allow Arm64 Linux packages to be downloaded.

## Changes
Removed the check for Arm64 and Linux to skip the download for the same. Also updated the folder structure display accordingly.

