### PR TITLE
Add ARM support in mde installer script

### DIFF
--- a/linux/installation/README.md
+++ b/linux/installation/README.md
@@ -15,7 +15,7 @@ chmod +x /mde_installer.sh
 
 ```bash
 ❯ ./mde_installer.sh --help
-mde_installer.sh v0.6.9
+mde_installer.sh v0.7.0
 usage: basename ./mde_installer.sh [OPTIONS]
 Options:
  -c|--channel         specify the channel(insiders-fast / insiders-slow / prod) from which you want to install. Default: prod
@@ -43,6 +43,8 @@ Options:
  --mdatp              specific version of mde to be installed. will use the latest if not provided
  -h|--help            display help
 ```
+
+> [!NOTE] ARM64 release is only available on insiders-slow channel
 
 ## Sample use case
 

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -748,11 +748,8 @@ install_on_fedora()
         repo_name=packages-microsoft-com-insiders-slow
     fi
 
-    if [ "$DISTRO" == "ol" ] || [ "$DISTRO" == "fedora" ]; then
+    if [ "$DISTRO" == "ol" ] || [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "amzn" ]; then
         effective_distro="rhel"
-    elif [ "$DISTRO" == "amzn" ]; then
-        effective_distro="amazonlinux"
-        SCALED_VERSION=$VERSION
     elif [ "$DISTRO" == "almalinux" ]; then
         effective_distro="alma"
     else
@@ -760,6 +757,10 @@ install_on_fedora()
     fi
 
     if [ "$ARCHITECTURE" == "aarch64" ]; then
+        if [ "$DISTRO" == "amzn" ]; then
+            effective_distro="amazonlinux"
+            SCALED_VERSION=$VERSION
+        fi
         log_info "[i] configuring the repository for ARM architecture"
         run_quietly "yum-config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo ($?)" $ERR_FAILED_REPO_SETUP
     fi

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -12,7 +12,7 @@
 #
 #============================================================================
 
-SCRIPT_VERSION="0.7.0"
+SCRIPT_VERSION="0.7.0" # MDE installer version set this to track the changes in the script used by tools like ansible, MDC etc.
 ASSUMEYES=-y
 CHANNEL=
 MDE_VERSION=
@@ -331,10 +331,15 @@ check_arm_distro_support()
         fi
     fi
 
-    ### ARM is released only on insiders slow channel
-    CHANNEL="insiders-slow"
-
-    log_info "[>] Your distribution is supported by MDE for ARM Linux"
+    ### ARM is released only on insiders slow channel channel
+    if [ "$OPT_FOR_MDE_ARM_PREVIEW" == "true" ] || [ "$OPT_FOR_MDE_ARM_PREVIEW" == "1" ]; then
+        CHANNEL="insiders-slow"
+        log_info "[>] Your distribution is supported by MDE for ARM Linux"
+    elif [ "$CHANNEL" == "insiders-slow" ]; then
+        log_info "[>] Your distribution is supported by MDE for ARM Linux"
+    else
+        script_exit "ARM architecture is not supported on $DISTRO" $ERR_UNSUPPORTED_ARCH
+    fi
 
 }
 
@@ -703,7 +708,6 @@ install_on_mariner()
     sleep 5
     log_info "[v] installed"
 }
-
 
 install_on_fedora()
 {
@@ -1414,7 +1418,7 @@ detect_arch
 ### Detect the distro and version number ###
 detect_distro
 
-### Check for ARM preview 
+### Check for ARM preview
 if [ "$ARCHITECTURE" == "aarch64" ]; then
     check_arm_distro_support
 fi


### PR DESCRIPTION
Issue: Current script doesn't support ARM64 architecture

Mitigation: Since MDE is now available on ARM64, we need to update the installer script to support ARM64 architecture.

Resolution: MDE released to insiders-slow channel of packages.microsoft.com. Hence this change will remove check which blocks ARM64 installation and set insiders-slow as default channel is customer wants to opt for preview version of MDE ARM64 OPT_FOR_MDE_ARM_PREVIEW=true or OPT_FOR_MDE_ARM_PREVIEW=1 else just pass insiders-slow as channel argument to install. This is only till MDE is in preview once it reaches GA it will follow same path as the x86-64 one.

Usage for ARM64:
[Recommended] sudo  ./linux/installation/mde_installer.sh --install --channel insiders-slow 
sudo OPT_FOR_MDE_ARM_PREVIEW=1 ./linux/installation/mde_installer.sh --install
sudo OPT_FOR_MDE_ARM_PREVIEW=true ./linux/installation/mde_installer.sh --install