### PR TITLE
Modify installation logic for ARM64

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -319,7 +319,10 @@ detect_distro()
 
 check_arm_distro_support()
 {
-    . /etc/mde.arm.d/mde.conf
+    FILE="/etc/mde.arm.d/mde.conf"
+    if [ -f $FILE ]; then
+        . "$FILE"
+    fi
     log_info "[>] OPT_FOR_MDE_ARM_PREVIEW: $OPT_FOR_MDE_ARM_PREVIEW"
     if [ "$ARCHITECTURE" == "aarch64" ]; then
         if [ "$DISTRO" != "ubuntu" ] && [ "$DISTRO" != "amzn" ]; then

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -763,20 +763,19 @@ install_on_fedora()
         ### Fetch the gpg key ###
         run_quietly "curl https://packages.microsoft.com/keys/microsoft.asc > microsoft.asc" "unable to fetch gpg key $?" $ERR_FAILED_REPO_SETUP
         run_quietly "rpm $(get_rpm_proxy_params) --import microsoft.asc" "unable to import gpg key" $ERR_FAILED_REPO_SETUP
-    fi
-
-    # Configure repository if it does not exist
-    yum -q repolist $repo_name | grep "$repo_name"
-    found_repo=$?
-    if [ $found_repo -eq 0 ]; then
-        log_info "[i] repository already configured"
     else
-        log_info "[i] configuring the repository"
-        run_quietly "yum-config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo ($?)" $ERR_FAILED_REPO_SETUP
-    fi
 
-    ### Fetch the gpg key ###
-    if [ "$ARCHITECTURE" != "aarch64" ]; then
+        # Configure repository if it does not exist
+        yum -q repolist $repo_name | grep "$repo_name"
+        found_repo=$?
+        if [ $found_repo -eq 0 ]; then
+            log_info "[i] repository already configured"
+        else
+            log_info "[i] configuring the repository"
+            run_quietly "yum-config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo ($?)" $ERR_FAILED_REPO_SETUP
+        fi
+
+        ### Fetch the gpg key ###
         run_quietly "curl https://packages.microsoft.com/keys/microsoft.asc > microsoft.asc" "unable to fetch gpg key $?" $ERR_FAILED_REPO_SETUP
         run_quietly "rpm $(get_rpm_proxy_params) --import microsoft.asc" "unable to import gpg key" $ERR_FAILED_REPO_SETUP
     fi


### PR DESCRIPTION
ARM is in preview hence should not be allowed unless intend to. Hence to avoid automation tool installing preview version without setting its intend. We are looking for variable defined in file /etc/mde.arm.d/mde.conf.