### PR TITLE
Fix shellcheck errors and warnings

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -1236,7 +1236,7 @@ offboard_device()
     for ((i = 1; i <= 15; i++)); do
         sleep 10 # Delay for 10 seconds before checking the license status
 
-         # Check if licensed field is false
+        # Check if licensed field is false
         if ! check_if_device_is_onboarded; then
             license_found=false
             break

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -366,15 +366,11 @@ verify_min_requirements()
     cores=$(nproc --all)
     if [ "$cores" -lt $MIN_CORES ]; then
         script_exit "MDE requires $MIN_CORES cores or more to run, found $cores." $ERR_INSUFFICIENT_REQUIREMENTS
-    elif [ "$cores" -lt $PREFERRED_MIN_CORES ]; then
-        log_warning "MDE recommends $PREFERRED_MIN_CORES cores or more to run all the features seamlessly, found $cores."
     fi
 
     mem_mb=$(free -m | grep Mem | awk '{print $2}')
     if [ "$mem_mb" -lt $MIN_MEM_MB ]; then
-        script_exit "MDE requires at least $MIN_MEM_MB MB of RAM to run. found $mem_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS 
-    elif [ "$mem_mb" -lt $PREFERRED_MIN_MEM_MB ]; then
-        log_warning "MDE recommends at least $PREFERRED_MIN_MEM_MB of RAM to run all the features seamlessly. found $mem_mb MB."
+        script_exit "MDE requires at least $MIN_MEM_MB MB of RAM to run. found $mem_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS
     fi
 
     disk_space_mb=$(df -m . | tail -1 | awk '{print $4}')

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -12,7 +12,7 @@
 #
 #============================================================================
 
-SCRIPT_VERSION="0.8.0" # MDE installer version set this to track the changes in the script used by tools like ansible, MDC etc.
+SCRIPT_VERSION="0.8.1" # MDE installer version set this to track the changes in the script used by tools like ansible, MDC etc.
 ASSUMEYES=-y
 CHANNEL=
 MDE_VERSION=
@@ -42,7 +42,6 @@ SUCCESS=0
 ERR_INTERNAL=1
 ERR_INVALID_ARGUMENTS=2
 ERR_INSUFFICIENT_PRIVILAGES=3
-ERR_NO_INTERNET_CONNECTIVITY=4
 ERR_CONFLICTING_APPS=5
 ERR_UNSUPPORTED_DISTRO=10
 ERR_UNSUPPORTED_VERSION=11
@@ -61,7 +60,6 @@ ERR_OFFBOARDING_NOT_FOUND=32
 ERR_OFFBOARDING_FAILED=33
 ERR_TAG_NOT_SUPPORTED=40
 ERR_PARAMETER_SET_FAILED=41
-ERR_UNSUPPORTED_ARCH=45
 
 # Predefined values
 export DEBIAN_FRONTEND=noninteractive
@@ -69,7 +67,7 @@ export DEBIAN_FRONTEND=noninteractive
 _log() {
     level="$1"
     dest="$2"
-    msg="${@:3}"
+    msg="${*:3}"
     ts=$(date -u +"%Y-%m-%dT%H:%M:%S")
 
     if [ "$dest" = "stdout" ]; then
@@ -138,7 +136,7 @@ get_python() {
 
 
 parse_uri() {
-   cat <<EOF | /usr/bin/env $(get_python)
+   cat <<EOF | /usr/bin/env "$(get_python)"
 import sys
 
 if sys.version_info < (3,):
@@ -190,8 +188,10 @@ run_quietly()
         exit 1
     fi
 
-    local out=$(eval $1 2>&1; echo "$?")
-    local exit_code=$(echo "$out" | tail -n1)
+    local out exit_code 
+
+    out=$(eval $1 2>&1; echo "$?")
+    exit_code=$(echo "$out" | tail -n1)
 
     if [ -n "$VERBOSE" ]; then
         log_info "$out"
@@ -205,13 +205,13 @@ run_quietly()
         fi
 
         if [ $# -eq 2 ]; then
-            log_error $2
+            log_error "$2"
         else
             script_exit "$2" "$3"
         fi
     fi
 
-    return $exit_code
+    return "$exit_code"
 }
 
 retry_quietly()
@@ -352,7 +352,7 @@ verify_privileges()
         script_exit "Internal error. verify_privileges require a parameter" $ERR_INTERNAL
     fi
 
-    if [ $(id -u) -ne 0 ]; then
+    if [ "$(id -u)" -ne 0 ]; then
         script_exit "root privileges required to perform $1 operation" $ERR_INSUFFICIENT_PRIVILAGES
     fi
 }
@@ -361,18 +361,24 @@ verify_min_requirements()
 {
     # verifying minimal reuirements: $MIN_CORES cores, $MIN_MEM_MB MB RAM, $MIN_DISK_SPACE_MB MB disk space
     
-    local cores=$(nproc --all)
-    if [ $cores -lt $MIN_CORES ]; then
+    local cores mem_mb disk_space_mb
+
+    cores=$(nproc --all)
+    if [ "$cores" -lt $MIN_CORES ]; then
         script_exit "MDE requires $MIN_CORES cores or more to run, found $cores." $ERR_INSUFFICIENT_REQUIREMENTS
+    elif [ "$cores" -lt $PREFERRED_MIN_CORES ]; then
+        log_warning "MDE recommends $PREFERRED_MIN_CORES cores or more to run all the features seamlessly, found $cores."
     fi
 
-    local mem_mb=$(free -m | grep Mem | awk '{print $2}')
-    if [ $mem_mb -lt $MIN_MEM_MB ]; then
-        script_exit "MDE requires at least $MIN_MEM_MB MB of RAM to run. found $mem_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS
+    mem_mb=$(free -m | grep Mem | awk '{print $2}')
+    if [ "$mem_mb" -lt $MIN_MEM_MB ]; then
+        script_exit "MDE requires at least $MIN_MEM_MB MB of RAM to run. found $mem_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS 
+    elif [ "$mem_mb" -lt $PREFERRED_MIN_MEM_MB ]; then
+        log_warning "MDE recommends at least $PREFERRED_MIN_MEM_MB of RAM to run all the features seamlessly. found $mem_mb MB."
     fi
 
-    local disk_space_mb=$(df -m . | tail -1 | awk '{print $4}')
-    if [ $disk_space_mb -lt $MIN_DISK_SPACE_MB ]; then
+    disk_space_mb=$(df -m . | tail -1 | awk '{print $4}')
+    if [ "$disk_space_mb" -lt $MIN_DISK_SPACE_MB ]; then
         script_exit "MDE requires at least $MIN_DISK_SPACE_MB MB of free disk space for installation. found $disk_space_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS
     fi
 
@@ -402,14 +408,15 @@ verify_mdatp_installed()
         #check if mdatp is onboarded or not
         check_missing_license=$(get_health_field "health_issues" | grep "missing license" -c)
         onboard_file=/etc/opt/microsoft/mdatp/mdatp_onboard.json
-        if ([ $check_missing_license -gt 0 ]) || ([ ! -f "$onboard_file" ]); then
+        if [ "$check_missing_license" -gt 0 ] || [ ! -f "$onboard_file" ]; then
             log_info "[i] MDE already installed but not onboarded. Please use --onboard command to onboard the product."
         else
             current_mdatp_version=$(get_health_field "app_version")
             org_id=$(get_health_field "org_id")          
             if [ ! -z "$MDE_VERSION" ]; then
-                local current_version=$(echo "$current_mdatp_version" | sed 's/"//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
-                local requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+                local current_version requested_version
+                current_version=$(echo "$current_mdatp_version" | sed 's/"//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+                requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
                 echo "[$current_mdatp_version]"
                 echo "[$current_version]"
                 echo "[$requested_version]"
@@ -433,7 +440,6 @@ verify_mdatp_installed()
 verify_conflicting_applications()
 {
     # identifying conflicting applications (fanotify mounts)
-
     if ! command -v timeout >/dev/null 2>&1; then
         log_warning "[!] 'timeout' command not found. Skipping conflicting application check"
         return
@@ -506,6 +512,7 @@ check_if_pkg_is_installed()
     if [ "$PKG_MGR" = "apt" ]; then
         dpkg -s $1 2> /dev/null | grep Status | grep "install ok installed" 1> /dev/null
     else
+        # shellcheck disable=SC2046
         rpm --quiet --query $(get_rpm_proxy_params) $1
     fi
 
@@ -568,11 +575,11 @@ get_mdatp_channel()
     fi
 
     local channel=""
-    if [[ "$release_ring" = *"Production"* ]]; then
+    if [[ "$release_ring" == *"Production"* ]]; then
         channel="prod"
-    elif [[ "$release_ring" = *"InsiderFast"* ]]; then
+    elif [[ "$release_ring" == *"InsiderFast"* ]]; then
         channel="insiders-fast"
-    elif [[ "$release_ring" = *"External"* ]]; then
+    elif [[ "$release_ring" == *"External"* ]]; then
         channel="insiders-slow"
     else
         channel="dogfood"
@@ -583,7 +590,7 @@ get_mdatp_channel()
 
 install_required_pkgs()
 {
-    local packages=
+    local packages=()
     local pkgs_to_be_installed=
 
     if [ -z "$1" ]; then
@@ -655,7 +662,8 @@ validate_mde_version()
     elif [ "$PKG_MGR" = "yum" ]; then
         check_option="yum --help | grep '\-\-showduplicates' &> /dev/null"
         eval $check_option
-        if [ $? -eq 0 ]; then
+        cmd_status=$?
+        if [ $cmd_status -eq 0 ]; then
             search_command='yum $ASSUMEYES -v list mdatp --showduplicates 2>/dev/null | grep "$version"  &> /dev/null'
         else
             search_command='echo &>/dev/null'
@@ -676,9 +684,8 @@ validate_mde_version()
 
 install_on_debian()
 {
-    local packages=
+    local packages=()
     local pkg_version=
-    local success=
 
     packages=(curl apt-transport-https gnupg)
 
@@ -729,10 +736,9 @@ install_on_debian()
 
 install_on_mariner()
 {
-    local packages=
+    local packages=()
     local pkg_version=
     local repo=
-    local effective_distro=
 
     # To use config-manager plugin, install dnf-plugins-core package
     run_quietly "$PKG_MGR_INVOKER install dnf-plugins-core" "failed to install dnf-plugins-core"
@@ -767,10 +773,9 @@ install_on_mariner()
 
 install_on_azurelinux()
 {
-    local packages=
+    local packages=()
     local pkg_version=
     local repo=
-    local effective_distro=
 
     # To use config-manager plugin, install dnf-plugins-core package
     run_quietly "$PKG_MGR_INVOKER install dnf-plugins-core" "failed to install dnf-plugins-core"
@@ -804,21 +809,21 @@ install_on_azurelinux()
 
 install_on_fedora()
 {
-    local packages=
+    local packages=()
     local pkg_version=
     local repo=packages-microsoft-com
     local effective_distro=
 
     # curl-minimal results into issues when present and trying to install curl, so skip installing
     # the curl over Amazon Linux 2023
-    if [[ "$VERSION" == "2023" ]] && [[ "$DISTRO" == "amzn" ]] && $(check_if_pkg_is_installed curl-minimal); then
+    if [[ "$VERSION" == "2023" ]] && [[ "$DISTRO" == "amzn" ]] && check_if_pkg_is_installed curl-minimal; then
         packages=(yum-utils)
     else
         packages=(curl yum-utils)
     fi
 
     if [[ $SCALED_VERSION == 7* ]] && [[ "$DISTRO" == "rhel" ]]; then
-        packages=($packages deltarpm)
+        packages=("${packages[@]}" deltarpm)
     fi
 
     install_required_pkgs "${packages[@]}"
@@ -834,44 +839,32 @@ install_on_fedora()
 
     if [ "$CHANNEL" == "insiders-slow" ] && [ "$DISTRO" != "rocky" ] && [ "$DISTRO" != "almalinux" ] && ! { [ "$DISTRO" == "rhel" ] && [[ "$SCALED_VERSION" == 9* ]]; }; then  # in case of insiders slow repo [except rocky and alma], the repo name is packages-microsoft-com-slow-prod
         #repo_name=${repo}-slow-prod
-        repo_name=packages-microsoft-com-insiders-slow
+        repo_name="packages-microsoft-com-insiders-slow"
     fi
 
-    if [ "$DISTRO" = "ol" ] || [ "$DISTRO" = "fedora" ] || [ "$DISTRO" = "amzn" ]; then
+    if [ "$DISTRO" = "ol" ] || [ "$DISTRO" = "fedora" ]; then
         effective_distro="rhel"
     elif [ "$DISTRO" = "almalinux" ]; then
         effective_distro="alma"
+    elif [ "$DISTRO" = "amzn" ]; then
+        effective_distro="amazonlinux"
     else
         effective_distro="$DISTRO"
     fi
 
-    if [ "$ARCHITECTURE" = "aarch64" ]; then
-        if [ "$DISTRO" = "amzn" ]; then
-            effective_distro="amazonlinux"
-            SCALED_VERSION=$VERSION
-        fi
-        log_info "[>] configuring the repository for ARM architecture"
-        run_quietly "yum-config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo ($?)" $ERR_FAILED_REPO_SETUP
-
-        ### Fetch the gpg key ###
-        run_quietly "curl https://packages.microsoft.com/keys/microsoft.asc > microsoft.asc" "unable to fetch gpg key $?" $ERR_FAILED_REPO_SETUP
-        run_quietly "rpm $(get_rpm_proxy_params) --import microsoft.asc" "unable to import gpg key" $ERR_FAILED_REPO_SETUP
+    # Configure repository if it does not exist
+    yum -q repolist "$repo_name" | grep "$repo_name"
+    found_repo=$?
+    if [ $found_repo -eq 0 ]; then
+        log_info "[i] repository already configured"
     else
-
-        # Configure repository if it does not exist
-        yum -q repolist $repo_name | grep "$repo_name"
-        found_repo=$?
-        if [ $found_repo -eq 0 ]; then
-            log_info "[i] repository already configured"
-        else
-            log_info "[>] configuring the repository"
-            run_quietly "yum-config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo ($?)" $ERR_FAILED_REPO_SETUP
-        fi
-
-        ### Fetch the gpg key ###
-        run_quietly "curl https://packages.microsoft.com/keys/microsoft.asc > microsoft.asc" "unable to fetch gpg key $?" $ERR_FAILED_REPO_SETUP
-        run_quietly "rpm $(get_rpm_proxy_params) --import microsoft.asc" "unable to import gpg key" $ERR_FAILED_REPO_SETUP
+        log_info "[>] configuring the repository"
+        run_quietly "yum-config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo ($?)" $ERR_FAILED_REPO_SETUP
     fi
+
+    ### Fetch the gpg key ###
+    run_quietly "curl https://packages.microsoft.com/keys/microsoft.asc > microsoft.asc" "unable to fetch gpg key $?" $ERR_FAILED_REPO_SETUP
+    run_quietly "rpm $(get_rpm_proxy_params) --import microsoft.asc" "unable to import gpg key" $ERR_FAILED_REPO_SETUP
 
     local version=""
     if [ ! -z "$MDE_VERSION" ]; then
@@ -896,7 +889,7 @@ install_on_fedora()
 
 install_on_sles()
 {
-    local packages=
+    local packages=()
     local pkg_version=
     local repo=packages-microsoft-com
 
@@ -907,7 +900,6 @@ install_on_sles()
     wait_for_package_manager_to_complete
 
     ### Configure the repository ###
-
     local repo_name=${repo}-${CHANNEL}
     if [ "$CHANNEL" = "insiders-slow" ]; then  # in case of insiders slow repo, the repo name is packages-microsoft-com-slow-prod
         repo_name=${repo}-slow-prod
@@ -948,7 +940,7 @@ install_on_sles()
     fi
 
     sleep 5
-    log_info "[v] Installation complete!."
+    log_info "[v] Installation complete!"
 }
 
 remove_repo()
@@ -966,7 +958,7 @@ remove_repo()
 
     local cmd_status
     # Remove configured packages.microsoft.com repository
-    if [ "$DISTRO" = 'sles' ] || [ "$DISTRO" = "sle-hpc" ]; then
+    if [ "$DISTRO" = "sles" ] || [ "$DISTRO" = "sle-hpc" ]; then
         local repo=packages-microsoft-com
         local repo_name=${repo}-${CHANNEL}
         if [ "$CHANNEL" = "insiders-slow" ]; then  # in case of insiders slow repo, the repo name is packages-microsoft-com-slow-prod
@@ -1017,10 +1009,11 @@ upgrade_mdatp()
 
     exit_if_mde_not_installed
 
-    local VERSION_BEFORE_UPDATE=$(get_mdatp_version)
+    local VERSION_BEFORE_UPDATE VERSION_AFTER_UPDATE version current_version requested_version
+    VERSION_BEFORE_UPDATE=$(get_mdatp_version)
     log_info "[i] Current $VERSION_BEFORE_UPDATE"
 
-    local version=""
+    version=""
     if [ ! -z "$MDE_VERSION" ]; then
         version=$(validate_mde_version)
         if [ -z "$version" ]; then
@@ -1028,18 +1021,18 @@ upgrade_mdatp()
         fi
     fi
 
-    local current_version=$(echo "$VERSION_BEFORE_UPDATE" | sed 's/^[ \t\n]*//;s/[ \t\n]*$//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
-    local requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+    current_version=$(echo "$VERSION_BEFORE_UPDATE" | sed 's/^[ \t\n]*//;s/[ \t\n]*$//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+    requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
 
-    if [[ "$INSTALL_MODE" = "d" && "$current_version" -lt "$requested_version" ]]; then
+    if [[ "$INSTALL_MODE" == "d" && "$current_version" -lt "$requested_version" ]]; then
         script_exit "For downgrade the requested version[$MDE_VERSION] should be older than current version[$VERSION_BEFORE_UPDATE]"
-    elif [[ "$INSTALL_MODE" = "u" && ! -z "$MDE_VERSION" && "$current_version" -gt "$requested_version" ]]; then
+    elif [[ "$INSTALL_MODE" == "u" && ! -z "$MDE_VERSION" && "$current_version" -gt "$requested_version" ]]; then
         script_exit "For upgrade the requested version[$MDE_VERSION] should be newer than current version[$VERSION_BEFORE_UPDATE]. If you want to move to an older version instead, retry with --downgrade flag"
     fi
 
     run_quietly "$PKG_MGR_INVOKER $1 mdatp$version" "Unable to upgrade MDE $?" $ERR_INSTALLATION_FAILED
 
-    local VERSION_AFTER_UPDATE=$(get_mdatp_version)
+    VERSION_AFTER_UPDATE=$(get_mdatp_version)
     if [ "$VERSION_BEFORE_UPDATE" = "$VERSION_AFTER_UPDATE" ]; then
         log_info "[i] MDE is already up to date."
     else
@@ -1082,7 +1075,7 @@ scale_version_id()
                script_exit "unsupported version: $DISTRO $VERSION" $ERR_UNSUPPORTED_VERSION
             fi
 
-        elif [[ $VERSION == 7* ]] || [[ "$DISTRO" == "amzn" ]]; then
+        elif [[ $VERSION == 7* ]]; then
             SCALED_VERSION=7
         elif [[ $VERSION == 8* ]] || [[ "$DISTRO" == "fedora" ]]; then
             SCALED_VERSION=8
@@ -1092,6 +1085,8 @@ scale_version_id()
             else
                 SCALED_VERSION=9.0
             fi
+        elif [[ $DISTRO == "amzn" ]] &&  [[ $VERSION == "2" || $VERSION == "2023" ]]; then # For Amazon Linux the scaled version is 2023 or 2
+            SCALED_VERSION=$VERSION
         else
             script_exit "unsupported version: $DISTRO $VERSION" $ERR_UNSUPPORTED_VERSION
         fi
@@ -1245,7 +1240,7 @@ offboard_device()
     for ((i = 1; i <= 15; i++)); do
         sleep 10 # Delay for 10 seconds before checking the license status
 
-        # Check if licensed field is false
+         # Check if licensed field is false
         if ! check_if_device_is_onboarded; then
             license_found=false
             break
@@ -1520,12 +1515,12 @@ if [ ! -z "$PASSIVE_MODE" ] && [ ! -z "$RTP_MODE" ]; then
 fi
 
 if [[ "$INSTALL_MODE" == 'i' && -z "$CHANNEL" ]]; then
-    log_info "[i] Specify the install channel using "--channel" argument. If not provided, mde will be installed for prod by default. Expected channel values: prod, insiders-slow, insiders-fast."
+    log_info "[i] Specify the install channel using \"--channel\" argument. If not provided, mde will be installed for prod by default. Expected channel values: prod, insiders-slow, insiders-fast."
     CHANNEL=prod
 fi
 
 if [[ "$INSTALL_MODE" == 'c' && -z "$CHANNEL" ]]; then
-    log_info "[i] Specify the cleanup channel using "--channel" argument. If not provided, prod repo will be cleaned up by default. Expected channel values: prod, insiders-slow, insiders-fast."
+    log_info "[i] Specify the cleanup channel using \"--channel\" argument. If not provided, prod repo will be cleaned up by default. Expected channel values: prod, insiders-slow, insiders-fast."
     CHANNEL=prod
 fi
 
@@ -1534,7 +1529,7 @@ if [[ "$INSTALL_MODE" == 'd' && -z "$MDE_VERSION" ]]; then
 fi
 
 if [[ -z "$MDE_VERSION" && ( "$INSTALL_MODE" == 'i' || "$INSTALL_MODE" == 'u' ) ]]; then
-    log_info "[i] Specify the version to be installed using "--mdatp" argument. If not provided, latest mde will be installed by default."
+    log_info "[i] Specify the version to be installed using \"--mdatp\" argument. If not provided, latest mde will be installed by default."
 fi
 
 

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -42,7 +42,6 @@ SUCCESS=0
 ERR_INTERNAL=1
 ERR_INVALID_ARGUMENTS=2
 ERR_INSUFFICIENT_PRIVILAGES=3
-ERR_NO_INTERNET_CONNECTIVITY=4
 ERR_CONFLICTING_APPS=5
 ERR_UNSUPPORTED_DISTRO=10
 ERR_UNSUPPORTED_VERSION=11
@@ -61,7 +60,6 @@ ERR_OFFBOARDING_NOT_FOUND=32
 ERR_OFFBOARDING_FAILED=33
 ERR_TAG_NOT_SUPPORTED=40
 ERR_PARAMETER_SET_FAILED=41
-ERR_UNSUPPORTED_ARCH=45
 
 # Predefined values
 export DEBIAN_FRONTEND=noninteractive
@@ -69,7 +67,7 @@ export DEBIAN_FRONTEND=noninteractive
 _log() {
     level="$1"
     dest="$2"
-    msg="${@:3}"
+    msg="${*:3}"
     ts=$(date -u +"%Y-%m-%dT%H:%M:%S")
 
     if [ "$dest" = "stdout" ]; then
@@ -138,7 +136,7 @@ get_python() {
 
 
 parse_uri() {
-   cat <<EOF | /usr/bin/env $(get_python)
+   cat <<EOF | /usr/bin/env "$(get_python)"
 import sys
 
 if sys.version_info < (3,):
@@ -190,8 +188,10 @@ run_quietly()
         exit 1
     fi
 
-    local out=$(eval $1 2>&1; echo "$?")
-    local exit_code=$(echo "$out" | tail -n1)
+    local out exit_code 
+
+    out=$(eval $1 2>&1; echo "$?")
+    exit_code=$(echo "$out" | tail -n1)
 
     if [ -n "$VERBOSE" ]; then
         log_info "$out"
@@ -205,13 +205,13 @@ run_quietly()
         fi
 
         if [ $# -eq 2 ]; then
-            log_error $2
+            log_error "$2"
         else
             script_exit "$2" "$3"
         fi
     fi
 
-    return $exit_code
+    return "$exit_code"
 }
 
 retry_quietly()
@@ -352,7 +352,7 @@ verify_privileges()
         script_exit "Internal error. verify_privileges require a parameter" $ERR_INTERNAL
     fi
 
-    if [ $(id -u) -ne 0 ]; then
+    if [ "$(id -u)" -ne 0 ]; then
         script_exit "root privileges required to perform $1 operation" $ERR_INSUFFICIENT_PRIVILAGES
     fi
 }
@@ -361,18 +361,20 @@ verify_min_requirements()
 {
     # verifying minimal reuirements: $MIN_CORES cores, $MIN_MEM_MB MB RAM, $MIN_DISK_SPACE_MB MB disk space
     
-    local cores=$(nproc --all)
-    if [ $cores -lt $MIN_CORES ]; then
+    local cores mem_mb disk_space_mb
+
+    cores=$(nproc --all)
+    if [ "$cores" -lt $MIN_CORES ]; then
         script_exit "MDE requires $MIN_CORES cores or more to run, found $cores." $ERR_INSUFFICIENT_REQUIREMENTS
     fi
 
-    local mem_mb=$(free -m | grep Mem | awk '{print $2}')
-    if [ $mem_mb -lt $MIN_MEM_MB ]; then
+    mem_mb=$(free -m | grep Mem | awk '{print $2}')
+    if [ "$mem_mb" -lt $MIN_MEM_MB ]; then
         script_exit "MDE requires at least $MIN_MEM_MB MB of RAM to run. found $mem_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS
     fi
 
-    local disk_space_mb=$(df -m . | tail -1 | awk '{print $4}')
-    if [ $disk_space_mb -lt $MIN_DISK_SPACE_MB ]; then
+    disk_space_mb=$(df -m . | tail -1 | awk '{print $4}')
+    if [ "$disk_space_mb" -lt $MIN_DISK_SPACE_MB ]; then
         script_exit "MDE requires at least $MIN_DISK_SPACE_MB MB of free disk space for installation. found $disk_space_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS
     fi
 
@@ -402,17 +404,15 @@ verify_mdatp_installed()
         #check if mdatp is onboarded or not
         check_missing_license=$(get_health_field "health_issues" | grep "missing license" -c)
         onboard_file=/etc/opt/microsoft/mdatp/mdatp_onboard.json
-        if ([ $check_missing_license -gt 0 ]) || ([ ! -f "$onboard_file" ]); then
+        if [ "$check_missing_license" -gt 0 ] || [ ! -f "$onboard_file" ]; then
             log_info "[i] MDE already installed but not onboarded. Please use --onboard command to onboard the product."
         else
             current_mdatp_version=$(get_health_field "app_version")
             org_id=$(get_health_field "org_id")          
             if [ ! -z "$MDE_VERSION" ]; then
-                local current_version=$(echo "$current_mdatp_version" | sed 's/"//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
-                local requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
-                echo "[$current_mdatp_version]"
-                echo "[$current_version]"
-                echo "[$requested_version]"
+                local current_version requested_version
+                current_version=$(echo "$current_mdatp_version" | sed 's/"//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+                requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
 
                 if [[ "$current_version" -lt "$requested_version" ]]; then
                     log_info "[i] Found MDE version $current_mdatp_version already installed and onboarded with org_id $org_id. To install newer version please use --upgrade option"
@@ -433,7 +433,6 @@ verify_mdatp_installed()
 verify_conflicting_applications()
 {
     # identifying conflicting applications (fanotify mounts)
-
     if ! command -v timeout >/dev/null 2>&1; then
         log_warning "[!] 'timeout' command not found. Skipping conflicting application check"
         return
@@ -506,6 +505,7 @@ check_if_pkg_is_installed()
     if [ "$PKG_MGR" = "apt" ]; then
         dpkg -s $1 2> /dev/null | grep Status | grep "install ok installed" 1> /dev/null
     else
+        # shellcheck disable=SC2046
         rpm --quiet --query $(get_rpm_proxy_params) $1
     fi
 
@@ -568,11 +568,11 @@ get_mdatp_channel()
     fi
 
     local channel=""
-    if [[ "$release_ring" = *"Production"* ]]; then
+    if [[ "$release_ring" == *"Production"* ]]; then
         channel="prod"
-    elif [[ "$release_ring" = *"InsiderFast"* ]]; then
+    elif [[ "$release_ring" == *"InsiderFast"* ]]; then
         channel="insiders-fast"
-    elif [[ "$release_ring" = *"External"* ]]; then
+    elif [[ "$release_ring" == *"External"* ]]; then
         channel="insiders-slow"
     else
         channel="dogfood"
@@ -583,7 +583,7 @@ get_mdatp_channel()
 
 install_required_pkgs()
 {
-    local packages=
+    local packages=()
     local pkgs_to_be_installed=
 
     if [ -z "$1" ]; then
@@ -655,7 +655,8 @@ validate_mde_version()
     elif [ "$PKG_MGR" = "yum" ]; then
         check_option="yum --help | grep '\-\-showduplicates' &> /dev/null"
         eval $check_option
-        if [ $? -eq 0 ]; then
+        cmd_status=$?
+        if [ $cmd_status -eq 0 ]; then
             search_command='yum $ASSUMEYES -v list mdatp --showduplicates 2>/dev/null | grep "$version"  &> /dev/null'
         else
             search_command='echo &>/dev/null'
@@ -676,9 +677,8 @@ validate_mde_version()
 
 install_on_debian()
 {
-    local packages=
+    local packages=()
     local pkg_version=
-    local success=
 
     packages=(curl apt-transport-https gnupg)
 
@@ -729,7 +729,7 @@ install_on_debian()
 
 install_on_mariner()
 {
-    local packages=
+    local packages=()
     local pkg_version=
     local repo=
 
@@ -766,7 +766,7 @@ install_on_mariner()
 
 install_on_azurelinux()
 {
-    local packages=
+    local packages=()
     local pkg_version=
     local repo=
 
@@ -802,21 +802,21 @@ install_on_azurelinux()
 
 install_on_fedora()
 {
-    local packages=
+    local packages=()
     local pkg_version=
     local repo=packages-microsoft-com
     local effective_distro=
 
     # curl-minimal results into issues when present and trying to install curl, so skip installing
     # the curl over Amazon Linux 2023
-    if [[ "$VERSION" == "2023" ]] && [[ "$DISTRO" == "amzn" ]] && $(check_if_pkg_is_installed curl-minimal); then
+    if [[ "$VERSION" == "2023" ]] && [[ "$DISTRO" == "amzn" ]] && check_if_pkg_is_installed curl-minimal; then
         packages=(yum-utils)
     else
         packages=(curl yum-utils)
     fi
 
     if [[ $SCALED_VERSION == 7* ]] && [[ "$DISTRO" == "rhel" ]]; then
-        packages=($packages deltarpm)
+        packages=("${packages[@]}" deltarpm)
     fi
 
     install_required_pkgs "${packages[@]}"
@@ -832,7 +832,7 @@ install_on_fedora()
 
     if [ "$CHANNEL" == "insiders-slow" ] && [ "$DISTRO" != "rocky" ] && [ "$DISTRO" != "almalinux" ] && ! { [ "$DISTRO" == "rhel" ] && [[ "$SCALED_VERSION" == 9* ]]; }; then  # in case of insiders slow repo [except rocky and alma], the repo name is packages-microsoft-com-slow-prod
         #repo_name=${repo}-slow-prod
-        repo_name=packages-microsoft-com-insiders-slow
+        repo_name="packages-microsoft-com-insiders-slow"
     fi
 
     if [ "$DISTRO" = "ol" ] || [ "$DISTRO" = "fedora" ]; then
@@ -846,7 +846,7 @@ install_on_fedora()
     fi
 
     # Configure repository if it does not exist
-    yum -q repolist $repo_name | grep "$repo_name"
+    yum -q repolist "$repo_name" | grep "$repo_name"
     found_repo=$?
     if [ $found_repo -eq 0 ]; then
         log_info "[i] repository already configured"
@@ -882,7 +882,7 @@ install_on_fedora()
 
 install_on_sles()
 {
-    local packages=
+    local packages=()
     local pkg_version=
     local repo=packages-microsoft-com
 
@@ -893,7 +893,6 @@ install_on_sles()
     wait_for_package_manager_to_complete
 
     ### Configure the repository ###
-
     local repo_name=${repo}-${CHANNEL}
     if [ "$CHANNEL" = "insiders-slow" ]; then  # in case of insiders slow repo, the repo name is packages-microsoft-com-slow-prod
         repo_name=${repo}-slow-prod
@@ -934,7 +933,7 @@ install_on_sles()
     fi
 
     sleep 5
-    log_info "[v] Installation complete!."
+    log_info "[v] Installation complete!"
 }
 
 remove_repo()
@@ -952,7 +951,7 @@ remove_repo()
 
     local cmd_status
     # Remove configured packages.microsoft.com repository
-    if [ "$DISTRO" = 'sles' ] || [ "$DISTRO" = "sle-hpc" ]; then
+    if [ "$DISTRO" = "sles" ] || [ "$DISTRO" = "sle-hpc" ]; then
         local repo=packages-microsoft-com
         local repo_name=${repo}-${CHANNEL}
         if [ "$CHANNEL" = "insiders-slow" ]; then  # in case of insiders slow repo, the repo name is packages-microsoft-com-slow-prod
@@ -1003,10 +1002,11 @@ upgrade_mdatp()
 
     exit_if_mde_not_installed
 
-    local VERSION_BEFORE_UPDATE=$(get_mdatp_version)
+    local VERSION_BEFORE_UPDATE VERSION_AFTER_UPDATE version current_version requested_version
+    VERSION_BEFORE_UPDATE=$(get_mdatp_version)
     log_info "[i] Current $VERSION_BEFORE_UPDATE"
 
-    local version=""
+    version=""
     if [ ! -z "$MDE_VERSION" ]; then
         version=$(validate_mde_version)
         if [ -z "$version" ]; then
@@ -1014,18 +1014,18 @@ upgrade_mdatp()
         fi
     fi
 
-    local current_version=$(echo "$VERSION_BEFORE_UPDATE" | sed 's/^[ \t\n]*//;s/[ \t\n]*$//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
-    local requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+    current_version=$(echo "$VERSION_BEFORE_UPDATE" | sed 's/^[ \t\n]*//;s/[ \t\n]*$//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+    requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
 
-    if [[ "$INSTALL_MODE" = "d" && "$current_version" -lt "$requested_version" ]]; then
+    if [[ "$INSTALL_MODE" == "d" && "$current_version" -lt "$requested_version" ]]; then
         script_exit "For downgrade the requested version[$MDE_VERSION] should be older than current version[$VERSION_BEFORE_UPDATE]"
-    elif [[ "$INSTALL_MODE" = "u" && ! -z "$MDE_VERSION" && "$current_version" -gt "$requested_version" ]]; then
+    elif [[ "$INSTALL_MODE" == "u" && ! -z "$MDE_VERSION" && "$current_version" -gt "$requested_version" ]]; then
         script_exit "For upgrade the requested version[$MDE_VERSION] should be newer than current version[$VERSION_BEFORE_UPDATE]. If you want to move to an older version instead, retry with --downgrade flag"
     fi
 
     run_quietly "$PKG_MGR_INVOKER $1 mdatp$version" "Unable to upgrade MDE $?" $ERR_INSTALLATION_FAILED
 
-    local VERSION_AFTER_UPDATE=$(get_mdatp_version)
+    VERSION_AFTER_UPDATE=$(get_mdatp_version)
     if [ "$VERSION_BEFORE_UPDATE" = "$VERSION_AFTER_UPDATE" ]; then
         log_info "[i] MDE is already up to date."
     else
@@ -1508,12 +1508,12 @@ if [ ! -z "$PASSIVE_MODE" ] && [ ! -z "$RTP_MODE" ]; then
 fi
 
 if [[ "$INSTALL_MODE" == 'i' && -z "$CHANNEL" ]]; then
-    log_info "[i] Specify the install channel using "--channel" argument. If not provided, mde will be installed for prod by default. Expected channel values: prod, insiders-slow, insiders-fast."
+    log_info "[i] Specify the install channel using \"--channel\" argument. If not provided, mde will be installed for prod by default. Expected channel values: prod, insiders-slow, insiders-fast."
     CHANNEL=prod
 fi
 
 if [[ "$INSTALL_MODE" == 'c' && -z "$CHANNEL" ]]; then
-    log_info "[i] Specify the cleanup channel using "--channel" argument. If not provided, prod repo will be cleaned up by default. Expected channel values: prod, insiders-slow, insiders-fast."
+    log_info "[i] Specify the cleanup channel using \"--channel\" argument. If not provided, prod repo will be cleaned up by default. Expected channel values: prod, insiders-slow, insiders-fast."
     CHANNEL=prod
 fi
 
@@ -1522,7 +1522,7 @@ if [[ "$INSTALL_MODE" == 'd' && -z "$MDE_VERSION" ]]; then
 fi
 
 if [[ -z "$MDE_VERSION" && ( "$INSTALL_MODE" == 'i' || "$INSTALL_MODE" == 'u' ) ]]; then
-    log_info "[i] Specify the version to be installed using "--mdatp" argument. If not provided, latest mde will be installed by default."
+    log_info "[i] Specify the version to be installed using \"--mdatp\" argument. If not provided, latest mde will be installed by default."
 fi
 
 

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -413,9 +413,6 @@ verify_mdatp_installed()
                 local current_version requested_version
                 current_version=$(echo "$current_mdatp_version" | sed 's/"//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
                 requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
-                echo "[$current_mdatp_version]"
-                echo "[$current_version]"
-                echo "[$requested_version]"
 
                 if [[ "$current_version" -lt "$requested_version" ]]; then
                     log_info "[i] Found MDE version $current_mdatp_version already installed and onboarded with org_id $org_id. To install newer version please use --upgrade option"

--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -42,6 +42,7 @@ SUCCESS=0
 ERR_INTERNAL=1
 ERR_INVALID_ARGUMENTS=2
 ERR_INSUFFICIENT_PRIVILAGES=3
+ERR_NO_INTERNET_CONNECTIVITY=4
 ERR_CONFLICTING_APPS=5
 ERR_UNSUPPORTED_DISTRO=10
 ERR_UNSUPPORTED_VERSION=11
@@ -60,6 +61,7 @@ ERR_OFFBOARDING_NOT_FOUND=32
 ERR_OFFBOARDING_FAILED=33
 ERR_TAG_NOT_SUPPORTED=40
 ERR_PARAMETER_SET_FAILED=41
+ERR_UNSUPPORTED_ARCH=45
 
 # Predefined values
 export DEBIAN_FRONTEND=noninteractive
@@ -67,7 +69,7 @@ export DEBIAN_FRONTEND=noninteractive
 _log() {
     level="$1"
     dest="$2"
-    msg="${*:3}"
+    msg="${@:3}"
     ts=$(date -u +"%Y-%m-%dT%H:%M:%S")
 
     if [ "$dest" = "stdout" ]; then
@@ -136,7 +138,7 @@ get_python() {
 
 
 parse_uri() {
-   cat <<EOF | /usr/bin/env "$(get_python)"
+   cat <<EOF | /usr/bin/env $(get_python)
 import sys
 
 if sys.version_info < (3,):
@@ -188,10 +190,8 @@ run_quietly()
         exit 1
     fi
 
-    local out exit_code 
-
-    out=$(eval $1 2>&1; echo "$?")
-    exit_code=$(echo "$out" | tail -n1)
+    local out=$(eval $1 2>&1; echo "$?")
+    local exit_code=$(echo "$out" | tail -n1)
 
     if [ -n "$VERBOSE" ]; then
         log_info "$out"
@@ -205,13 +205,13 @@ run_quietly()
         fi
 
         if [ $# -eq 2 ]; then
-            log_error "$2"
+            log_error $2
         else
             script_exit "$2" "$3"
         fi
     fi
 
-    return "$exit_code"
+    return $exit_code
 }
 
 retry_quietly()
@@ -352,7 +352,7 @@ verify_privileges()
         script_exit "Internal error. verify_privileges require a parameter" $ERR_INTERNAL
     fi
 
-    if [ "$(id -u)" -ne 0 ]; then
+    if [ $(id -u) -ne 0 ]; then
         script_exit "root privileges required to perform $1 operation" $ERR_INSUFFICIENT_PRIVILAGES
     fi
 }
@@ -361,20 +361,18 @@ verify_min_requirements()
 {
     # verifying minimal reuirements: $MIN_CORES cores, $MIN_MEM_MB MB RAM, $MIN_DISK_SPACE_MB MB disk space
     
-    local cores mem_mb disk_space_mb
-
-    cores=$(nproc --all)
-    if [ "$cores" -lt $MIN_CORES ]; then
+    local cores=$(nproc --all)
+    if [ $cores -lt $MIN_CORES ]; then
         script_exit "MDE requires $MIN_CORES cores or more to run, found $cores." $ERR_INSUFFICIENT_REQUIREMENTS
     fi
 
-    mem_mb=$(free -m | grep Mem | awk '{print $2}')
-    if [ "$mem_mb" -lt $MIN_MEM_MB ]; then
+    local mem_mb=$(free -m | grep Mem | awk '{print $2}')
+    if [ $mem_mb -lt $MIN_MEM_MB ]; then
         script_exit "MDE requires at least $MIN_MEM_MB MB of RAM to run. found $mem_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS
     fi
 
-    disk_space_mb=$(df -m . | tail -1 | awk '{print $4}')
-    if [ "$disk_space_mb" -lt $MIN_DISK_SPACE_MB ]; then
+    local disk_space_mb=$(df -m . | tail -1 | awk '{print $4}')
+    if [ $disk_space_mb -lt $MIN_DISK_SPACE_MB ]; then
         script_exit "MDE requires at least $MIN_DISK_SPACE_MB MB of free disk space for installation. found $disk_space_mb MB." $ERR_INSUFFICIENT_REQUIREMENTS
     fi
 
@@ -404,15 +402,17 @@ verify_mdatp_installed()
         #check if mdatp is onboarded or not
         check_missing_license=$(get_health_field "health_issues" | grep "missing license" -c)
         onboard_file=/etc/opt/microsoft/mdatp/mdatp_onboard.json
-        if [ "$check_missing_license" -gt 0 ] || [ ! -f "$onboard_file" ]; then
+        if ([ $check_missing_license -gt 0 ]) || ([ ! -f "$onboard_file" ]); then
             log_info "[i] MDE already installed but not onboarded. Please use --onboard command to onboard the product."
         else
             current_mdatp_version=$(get_health_field "app_version")
             org_id=$(get_health_field "org_id")          
             if [ ! -z "$MDE_VERSION" ]; then
-                local current_version requested_version
-                current_version=$(echo "$current_mdatp_version" | sed 's/"//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
-                requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+                local current_version=$(echo "$current_mdatp_version" | sed 's/"//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+                local requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+                echo "[$current_mdatp_version]"
+                echo "[$current_version]"
+                echo "[$requested_version]"
 
                 if [[ "$current_version" -lt "$requested_version" ]]; then
                     log_info "[i] Found MDE version $current_mdatp_version already installed and onboarded with org_id $org_id. To install newer version please use --upgrade option"
@@ -433,6 +433,7 @@ verify_mdatp_installed()
 verify_conflicting_applications()
 {
     # identifying conflicting applications (fanotify mounts)
+
     if ! command -v timeout >/dev/null 2>&1; then
         log_warning "[!] 'timeout' command not found. Skipping conflicting application check"
         return
@@ -505,7 +506,6 @@ check_if_pkg_is_installed()
     if [ "$PKG_MGR" = "apt" ]; then
         dpkg -s $1 2> /dev/null | grep Status | grep "install ok installed" 1> /dev/null
     else
-        # shellcheck disable=SC2046
         rpm --quiet --query $(get_rpm_proxy_params) $1
     fi
 
@@ -568,11 +568,11 @@ get_mdatp_channel()
     fi
 
     local channel=""
-    if [[ "$release_ring" == *"Production"* ]]; then
+    if [[ "$release_ring" = *"Production"* ]]; then
         channel="prod"
-    elif [[ "$release_ring" == *"InsiderFast"* ]]; then
+    elif [[ "$release_ring" = *"InsiderFast"* ]]; then
         channel="insiders-fast"
-    elif [[ "$release_ring" == *"External"* ]]; then
+    elif [[ "$release_ring" = *"External"* ]]; then
         channel="insiders-slow"
     else
         channel="dogfood"
@@ -583,7 +583,7 @@ get_mdatp_channel()
 
 install_required_pkgs()
 {
-    local packages=()
+    local packages=
     local pkgs_to_be_installed=
 
     if [ -z "$1" ]; then
@@ -655,8 +655,7 @@ validate_mde_version()
     elif [ "$PKG_MGR" = "yum" ]; then
         check_option="yum --help | grep '\-\-showduplicates' &> /dev/null"
         eval $check_option
-        cmd_status=$?
-        if [ $cmd_status -eq 0 ]; then
+        if [ $? -eq 0 ]; then
             search_command='yum $ASSUMEYES -v list mdatp --showduplicates 2>/dev/null | grep "$version"  &> /dev/null'
         else
             search_command='echo &>/dev/null'
@@ -677,8 +676,9 @@ validate_mde_version()
 
 install_on_debian()
 {
-    local packages=()
+    local packages=
     local pkg_version=
+    local success=
 
     packages=(curl apt-transport-https gnupg)
 
@@ -729,7 +729,7 @@ install_on_debian()
 
 install_on_mariner()
 {
-    local packages=()
+    local packages=
     local pkg_version=
     local repo=
 
@@ -766,7 +766,7 @@ install_on_mariner()
 
 install_on_azurelinux()
 {
-    local packages=()
+    local packages=
     local pkg_version=
     local repo=
 
@@ -802,21 +802,21 @@ install_on_azurelinux()
 
 install_on_fedora()
 {
-    local packages=()
+    local packages=
     local pkg_version=
     local repo=packages-microsoft-com
     local effective_distro=
 
     # curl-minimal results into issues when present and trying to install curl, so skip installing
     # the curl over Amazon Linux 2023
-    if [[ "$VERSION" == "2023" ]] && [[ "$DISTRO" == "amzn" ]] && check_if_pkg_is_installed curl-minimal; then
+    if [[ "$VERSION" == "2023" ]] && [[ "$DISTRO" == "amzn" ]] && $(check_if_pkg_is_installed curl-minimal); then
         packages=(yum-utils)
     else
         packages=(curl yum-utils)
     fi
 
     if [[ $SCALED_VERSION == 7* ]] && [[ "$DISTRO" == "rhel" ]]; then
-        packages=("${packages[@]}" deltarpm)
+        packages=($packages deltarpm)
     fi
 
     install_required_pkgs "${packages[@]}"
@@ -832,7 +832,7 @@ install_on_fedora()
 
     if [ "$CHANNEL" == "insiders-slow" ] && [ "$DISTRO" != "rocky" ] && [ "$DISTRO" != "almalinux" ] && ! { [ "$DISTRO" == "rhel" ] && [[ "$SCALED_VERSION" == 9* ]]; }; then  # in case of insiders slow repo [except rocky and alma], the repo name is packages-microsoft-com-slow-prod
         #repo_name=${repo}-slow-prod
-        repo_name="packages-microsoft-com-insiders-slow"
+        repo_name=packages-microsoft-com-insiders-slow
     fi
 
     if [ "$DISTRO" = "ol" ] || [ "$DISTRO" = "fedora" ]; then
@@ -846,7 +846,7 @@ install_on_fedora()
     fi
 
     # Configure repository if it does not exist
-    yum -q repolist "$repo_name" | grep "$repo_name"
+    yum -q repolist $repo_name | grep "$repo_name"
     found_repo=$?
     if [ $found_repo -eq 0 ]; then
         log_info "[i] repository already configured"
@@ -882,7 +882,7 @@ install_on_fedora()
 
 install_on_sles()
 {
-    local packages=()
+    local packages=
     local pkg_version=
     local repo=packages-microsoft-com
 
@@ -893,6 +893,7 @@ install_on_sles()
     wait_for_package_manager_to_complete
 
     ### Configure the repository ###
+
     local repo_name=${repo}-${CHANNEL}
     if [ "$CHANNEL" = "insiders-slow" ]; then  # in case of insiders slow repo, the repo name is packages-microsoft-com-slow-prod
         repo_name=${repo}-slow-prod
@@ -933,7 +934,7 @@ install_on_sles()
     fi
 
     sleep 5
-    log_info "[v] Installation complete!"
+    log_info "[v] Installation complete!."
 }
 
 remove_repo()
@@ -951,7 +952,7 @@ remove_repo()
 
     local cmd_status
     # Remove configured packages.microsoft.com repository
-    if [ "$DISTRO" = "sles" ] || [ "$DISTRO" = "sle-hpc" ]; then
+    if [ "$DISTRO" = 'sles' ] || [ "$DISTRO" = "sle-hpc" ]; then
         local repo=packages-microsoft-com
         local repo_name=${repo}-${CHANNEL}
         if [ "$CHANNEL" = "insiders-slow" ]; then  # in case of insiders slow repo, the repo name is packages-microsoft-com-slow-prod
@@ -1002,11 +1003,10 @@ upgrade_mdatp()
 
     exit_if_mde_not_installed
 
-    local VERSION_BEFORE_UPDATE VERSION_AFTER_UPDATE version current_version requested_version
-    VERSION_BEFORE_UPDATE=$(get_mdatp_version)
+    local VERSION_BEFORE_UPDATE=$(get_mdatp_version)
     log_info "[i] Current $VERSION_BEFORE_UPDATE"
 
-    version=""
+    local version=""
     if [ ! -z "$MDE_VERSION" ]; then
         version=$(validate_mde_version)
         if [ -z "$version" ]; then
@@ -1014,18 +1014,18 @@ upgrade_mdatp()
         fi
     fi
 
-    current_version=$(echo "$VERSION_BEFORE_UPDATE" | sed 's/^[ \t\n]*//;s/[ \t\n]*$//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
-    requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+    local current_version=$(echo "$VERSION_BEFORE_UPDATE" | sed 's/^[ \t\n]*//;s/[ \t\n]*$//' | awk '{print $NF}' | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
+    local requested_version=$(echo "$MDE_VERSION" | awk -F. '{ printf("%d%05d%05d\n", $1,$2,$3); }')
 
-    if [[ "$INSTALL_MODE" == "d" && "$current_version" -lt "$requested_version" ]]; then
+    if [[ "$INSTALL_MODE" = "d" && "$current_version" -lt "$requested_version" ]]; then
         script_exit "For downgrade the requested version[$MDE_VERSION] should be older than current version[$VERSION_BEFORE_UPDATE]"
-    elif [[ "$INSTALL_MODE" == "u" && ! -z "$MDE_VERSION" && "$current_version" -gt "$requested_version" ]]; then
+    elif [[ "$INSTALL_MODE" = "u" && ! -z "$MDE_VERSION" && "$current_version" -gt "$requested_version" ]]; then
         script_exit "For upgrade the requested version[$MDE_VERSION] should be newer than current version[$VERSION_BEFORE_UPDATE]. If you want to move to an older version instead, retry with --downgrade flag"
     fi
 
     run_quietly "$PKG_MGR_INVOKER $1 mdatp$version" "Unable to upgrade MDE $?" $ERR_INSTALLATION_FAILED
 
-    VERSION_AFTER_UPDATE=$(get_mdatp_version)
+    local VERSION_AFTER_UPDATE=$(get_mdatp_version)
     if [ "$VERSION_BEFORE_UPDATE" = "$VERSION_AFTER_UPDATE" ]; then
         log_info "[i] MDE is already up to date."
     else
@@ -1508,12 +1508,12 @@ if [ ! -z "$PASSIVE_MODE" ] && [ ! -z "$RTP_MODE" ]; then
 fi
 
 if [[ "$INSTALL_MODE" == 'i' && -z "$CHANNEL" ]]; then
-    log_info "[i] Specify the install channel using \"--channel\" argument. If not provided, mde will be installed for prod by default. Expected channel values: prod, insiders-slow, insiders-fast."
+    log_info "[i] Specify the install channel using "--channel" argument. If not provided, mde will be installed for prod by default. Expected channel values: prod, insiders-slow, insiders-fast."
     CHANNEL=prod
 fi
 
 if [[ "$INSTALL_MODE" == 'c' && -z "$CHANNEL" ]]; then
-    log_info "[i] Specify the cleanup channel using \"--channel\" argument. If not provided, prod repo will be cleaned up by default. Expected channel values: prod, insiders-slow, insiders-fast."
+    log_info "[i] Specify the cleanup channel using "--channel" argument. If not provided, prod repo will be cleaned up by default. Expected channel values: prod, insiders-slow, insiders-fast."
     CHANNEL=prod
 fi
 
@@ -1522,7 +1522,7 @@ if [[ "$INSTALL_MODE" == 'd' && -z "$MDE_VERSION" ]]; then
 fi
 
 if [[ -z "$MDE_VERSION" && ( "$INSTALL_MODE" == 'i' || "$INSTALL_MODE" == 'u' ) ]]; then
-    log_info "[i] Specify the version to be installed using \"--mdatp\" argument. If not provided, latest mde will be installed by default."
+    log_info "[i] Specify the version to be installed using "--mdatp" argument. If not provided, latest mde will be installed by default."
 fi
 
 


### PR DESCRIPTION
Fixed the following shellcheck errors and warnings. 
suppressed SC2319 as it is not relevant to our code.

The description of the warnings are given below:
Code | Count | Description
SC2155 | 10 | Declare and assign separately to avoid masking return values
SC2178 | 5 | Variable was used as an array but is now assigned a string
SC2046 | 3 | Quote this to prevent word splitting
SC2124 | 1 | Assigning an array to a string — use * instead of @ to concatenate
SC2034 | 1 | Unused variable — consider removing or exporting
SC2128 | 1 | Expanding array without index gives only first element
SC2206 | 1 | Quote to prevent splitting/globbing or use mapfile/read -a
SC2100 | 1 | Use ((..)) for arithmetic instead of let or older syntax
SC2091 | 1 | Avoid executing output with $(...) — use eval if intended
SC2076 | 1 | Remove quotes around RHS of =~ to use regex matching
SC2140 | 3 | Confusing "A"B"C" style — ShellCheck can't tell if you meant "ABC" or "A\"B\"C"