### PR TITLE
Do key install only when adding repo, but skip if repo already exists.

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -853,11 +853,10 @@ install_on_fedora()
     else
         log_info "[>] configuring the repository"
         run_quietly "yum-config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo ($?)" $ERR_FAILED_REPO_SETUP
+        ### Fetch the gpg key ###
+        run_quietly "curl https://packages.microsoft.com/keys/microsoft.asc > microsoft.asc" "unable to fetch gpg key $?" $ERR_FAILED_REPO_SETUP
+        run_quietly "rpm $(get_rpm_proxy_params) --import microsoft.asc" "unable to import gpg key" $ERR_FAILED_REPO_SETUP
     fi
-
-    ### Fetch the gpg key ###
-    run_quietly "curl https://packages.microsoft.com/keys/microsoft.asc > microsoft.asc" "unable to fetch gpg key $?" $ERR_FAILED_REPO_SETUP
-    run_quietly "rpm $(get_rpm_proxy_params) --import microsoft.asc" "unable to import gpg key" $ERR_FAILED_REPO_SETUP
 
     local version=""
     if [ ! -z "$MDE_VERSION" ]; then


### PR DESCRIPTION
This change shifts the logic, for Fedora distros, of fetching and installing the gpg key for the repository to only occur when the repository does not exist and is being added. Currently, the Fedora install detects if the repo already exists in the repo list, and if so will bypass attempting to add it, but will still fetch and install the repo key. In a scenario where the repo is pre-staged, for the purposes of using a local package mirror, and the machine does not have direct internet access this would still cause the installation to fail.