### PR TITLE
Fixing Linux installer script for CentOS 9

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -1075,11 +1075,7 @@ scale_version_id()
         elif [[ $VERSION == 8* ]] || [[ "$DISTRO" == "fedora" ]]; then
             SCALED_VERSION=8
         elif [[ $VERSION == 9* ]]; then
-            if [[ $DISTRO == "almalinux" || $DISTRO == "rocky" ]]; then
-                SCALED_VERSION=9
-            else
-                SCALED_VERSION=9.0
-            fi
+	    SCALED_VERSION=9
         elif [[ $DISTRO == "amzn" ]] &&  [[ $VERSION == "2" || $VERSION == "2023" ]]; then # For Amazon Linux the scaled version is 2023 or 2
             SCALED_VERSION=$VERSION
         else


### PR DESCRIPTION
The current version of the installer script fails for CentOS 9.

The following error occurs:
```
--- mde_installer.sh v0.8.2 ---
[v] minimal requirements met
[v] detected: x86_64 architecture
[v] detected: centos 9  (fedora)
[v] scaled: 9.0
[v] set package manager: yum
[v] no conflicting applications found
[v] required pkgs are installed
[>] configuring the repository
[>] configuring the repository
Adding repo from: https://packages.microsoft.com/config/centos/9.0/prod.repo
Status code: 404 for https://packages.microsoft.com/config/centos/9.0/prod.repo (IP: 13.107.253.72)
Error: Configuration of repo failed
1
[x] Unable to fetch the repo (0)
[*] exiting (24)
```

Similar to PR #132, the scaled version needs to be adjusted.