### PR TITLE
Add support for RHEL version 10 in mde_installer.sh

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -1248,6 +1248,8 @@ scale_version_id()
             else
                 SCALED_VERSION=9.0
             fi
+		elif [[ $VERSION == 10* ]]; then
+            SCALED_VERSION=10
         elif [[ $DISTRO == "amzn" ]] &&  [[ $VERSION == "2" || $VERSION == "2023" ]]; then # For Amazon Linux the scaled version is 2023 or 2
             SCALED_VERSION=$VERSION
         else


### PR DESCRIPTION
Add support for RHEL 10 in MDE installer script.
```

Current state: 
[i] Specify the install channel using "--channel" argument. If not provided, mde will be installed for prod by default. Expected channel values: prod, insiders-slow, insiders-fast.
[i] Specify the version to be installed using "--mdatp" argument. If not provided, latest mde will be installed by default.
--- mde_installer.sh v0.8.2 ---
[v] detected: x86_64 architecture
[v] detected: rhel 10.0  (fedora)
[x] unsupported version: rhel 10.0
[*] exiting (11)

```
After fix for version. Script works successfully.
