### PR TITLE
fix: support DNF5 config-manager syntax for repository setup in mde_installer.sh

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -1610,7 +1610,11 @@ install_on_fedora()
 
             # Use appropriate config manager based on package manager
             if [ "$PKG_MGR" = "dnf" ]; then
-                run_quietly "dnf config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo" $ERR_FAILED_REPO_SETUP
+                if command -v dnf5 >/dev/null 2>&1; then
+                    run_quietly "dnf config-manager addrepo --from-repofile=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo" $ERR_FAILED_REPO_SETUP
+                else
+                    run_quietly "dnf config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo" $ERR_FAILED_REPO_SETUP
+                fi
             else
                 run_quietly "yum-config-manager --add-repo=$PMC_URL/$effective_distro/$SCALED_VERSION/$CHANNEL.repo" "Unable to fetch the repo" $ERR_FAILED_REPO_SETUP
             fi


### PR DESCRIPTION
## Problem

On systems running DNF5 (Fedora 42+), `mde_installer.sh` fails
when adding the Microsoft package repository with:

```
Unknown argument "--add-repo=https://packages.microsoft.com/config/rhel/8/prod.repo" for command "config-manager". Add "--help" for more information about the arguments.
```

## Root cause

The `--add-repo` flag was removed in DNF5 and replaced with a new subcommand:

```sh
dnf config-manager addrepo --from-repofile=<url>
```

Reference: https://dnf5.readthedocs.io/en/latest/dnf5_plugins/config-manager.8.html#subcommands

## Fix
Detect DNF5 at runtime via `command -v dnf5` and use the appropriate syntax:

```sh
if command -v dnf5 >/dev/null 2>&1; then
    dnf config-manager addrepo --from-repofile=<url>
else
    dnf config-manager --add-repo=<url>
fi
```

## Tested on
- Fedora 43 (DNF5 5.2.17.0) — previously failing, now works 