### PR TITLE
Add support for CentOS Stream 9 and RHEL 9 in version check

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -1876,7 +1876,7 @@ scale_version_id()
         elif [[ $VERSION == 8* ]] || [[ "$DISTRO" == "fedora" ]]; then
             SCALED_VERSION=8
         elif [[ $VERSION == 9* ]]; then
-            if [[ $DISTRO == "almalinux" || $DISTRO == "rocky" ]]; then
+            if [[ $DISTRO == "almalinux" || $DISTRO == "rocky" || $DISTRO == "centos" || $DISTRO == "rhel" ]]; then
                 SCALED_VERSION=9
             else
                 SCALED_VERSION=9.0


### PR DESCRIPTION
Add support for CentOS Stream 9 and RHEL 9 in version check

I use CentOS Stream 9 as my workstation.

The installation works after the patch.

Also the `eicar.com.txt` testing procedure works as per the instructions here:
https://learn.microsoft.com/en-us/defender-endpoint/linux-installer-script
