### PR TITLE
Microsoft AutoUpdate (MAU) for macOS preferences using deprecated ChannelName setting

### DIFF
--- a/macos/settings/microsoft_auto_update/com.microsoft.autoupdate2.mobileconfig
+++ b/macos/settings/microsoft_auto_update/com.microsoft.autoupdate2.mobileconfig
@@ -42,7 +42,7 @@
             <key>PayloadEnabled</key>
             <true/>
             <key>ChannelName</key>
-            <string>Production</string>
+            <string>Current</string>
             <key>HowToCheck</key>
             <string>AutomaticDownload</string>
             <key>EnableCheckForUpdatesButton</key>

--- a/macos/settings/microsoft_auto_update/com.microsoft.autoupdate2.plist
+++ b/macos/settings/microsoft_auto_update/com.microsoft.autoupdate2.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>ChannelName</key>
-        <string>Production</string>
+        <string>Current</string>
         <key>HowToCheck</key>
         <string>AutomaticDownload</string>
         <key>EnableCheckForUpdatesButton</key>


### PR DESCRIPTION
The value for ChannelName in the AutoUpdate preferences is out of date.

It uses 'Production' but this is now deprecated - should use 'Channel' instead https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences#channelname