### PR TITLE
feat(installer): add Rocky Linux 10 and AlmaLinux 10 support

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -12,7 +12,7 @@
 #
 #============================================================================
 
-SCRIPT_VERSION="1.2.2" # MDE installer version set this to track the changes in the script used by tools like ansible, MDC etc.
+SCRIPT_VERSION="1.2.3" # MDE installer version set this to track the changes in the script used by tools like ansible, MDC etc.
 ASSUMEYES=-y
 CHANNEL=
 MDE_VERSION=
@@ -610,10 +610,10 @@ verify_supported_distros()
             $is_arm && log_warning "$os_not_supported_msg" || (( VERSION >= 33 && VERSION <= 38 )) || log_warning "$os_not_supported_msg"
             ;;
         almalinux)
-            $is_arm && log_warning "$os_not_supported_msg" || [[ "$major" == 8 && "$minor" -ge 4 || "$major" == 9 && "$minor" -ge 2 ]] || log_warning "$os_not_supported_msg"
+            [[ "$major" == 10 ]] || [[ "$major" == 8 && "$minor" -ge 4 || "$major" == 9 && "$minor" -ge 2 ]] || log_warning "$os_not_supported_msg"
             ;;
         rocky)
-            $is_arm && log_warning "$os_not_supported_msg" || [[ "$major" == 8 && "$minor" -ge 7 || "$major" == 9 && "$minor" -ge 2 ]] || log_warning "$os_not_supported_msg"
+            [[ ( "$major" == 8 && "$minor" -ge 7 ) || ( "$major" == 9 && "$minor" -ge 2 ) || "$major" == 10 ]] || log_warning "$os_not_supported_msg"
             ;;
         mariner)
             $is_arm && log_warning "$os_not_supported_msg" || [[ "$VERSION" == 2 ]] || log_warning "$os_not_supported_msg"
@@ -1913,7 +1913,7 @@ scale_version_id()
             else
                 SCALED_VERSION=9.0
             fi
-        elif [[ "$VERSION" == 10* ]] && [[ "$DISTRO" == "centos" || "$DISTRO" == "rhel" || "$DISTRO" == "ol" ]]; then
+        elif [[ "$VERSION" == 10* ]] && [[ "$DISTRO" == "centos" || "$DISTRO" == "rhel" || "$DISTRO" == "ol" || "$DISTRO" == "almalinux" || "$DISTRO" == "rocky" ]]; then
             SCALED_VERSION=10
         elif [[ $DISTRO == "amzn" ]] &&  [[ $VERSION == "2" || $VERSION == "2023" ]]; then # For Amazon Linux the scaled version is 2023 or 2
             SCALED_VERSION=$VERSION


### PR DESCRIPTION
## Summary
Adds `mde_installer.sh` support for **Rocky Linux 10** and **AlmaLinux 10**, whose packages are now published on packages.microsoft.com.

This is **part 1 of 2** splitting the original combined PR #244. SLES 16 and Fedora 43 follow in a separate PR.

## Changes
- `verify_supported_distros`: accept AlmaLinux 10 and Rocky Linux 10 (including arm64).
- `scale_version_id`: map `almalinux`/`rocky` version `10*` to `SCALED_VERSION=10`, so installs use the existing `alma/10` and `rocky/10` PMC repos.
- Bump `SCRIPT_VERSION` to `1.2.3` (shared with AlmaLinux 10 as the two distros are equivalent for this change).

## Testing
Validated against the internal installer CI matrix (rocky10, almalinux-x86_64:10, almalinux-arm:10 legs).

> Draft: kept in draft pending review of the internal Rocky/Alma PRs.