### PR TITLE
feat(installer): add openSUSE Leap 15.6 and 16 support

### DIFF
--- a/linux/installation/mde_installer.sh
+++ b/linux/installation/mde_installer.sh
@@ -12,7 +12,7 @@
 #
 #============================================================================
 
-SCRIPT_VERSION="1.2.4" # MDE installer version set this to track the changes in the script used by tools like ansible, MDC etc.
+SCRIPT_VERSION="1.2.5" # MDE installer version set this to track the changes in the script used by tools like ansible, MDC etc.
 ASSUMEYES=-y
 CHANNEL=
 MDE_VERSION=
@@ -302,7 +302,7 @@ detect_distro()
         DISTRO_FAMILY="mariner"
     elif [ "$DISTRO" = "azurelinux" ]; then
         DISTRO_FAMILY="azurelinux"
-    elif [ "$DISTRO" = "sles" ] || [ "$DISTRO" = "sle-hpc" ] || [ "$DISTRO" = "sles_sap" ]; then
+    elif [ "$DISTRO" = "sles" ] || [ "$DISTRO" = "sle-hpc" ] || [ "$DISTRO" = "sles_sap" ] || [ "$DISTRO" = "opensuse-leap" ] || [ "$DISTRO" = "opensuse" ]; then
         DISTRO_FAMILY="sles"
     else
         script_exit "unsupported distro $DISTRO $VERSION" $ERR_UNSUPPORTED_DISTRO


### PR DESCRIPTION
## Summary
Adds `mde_installer.sh` support for **openSUSE Leap 15.6** and **openSUSE Leap 16**.

openSUSE Leap is binary-compatible with SLES and uses `zypper`, so it is routed through the existing SLES family and installs from the maintained `config/sles/15` and `config/sles/16` repositories on packages.microsoft.com.

Without this change `detect_distro` does not recognise `opensuse-leap`, so the installer exits with `unsupported distro` on every openSUSE Leap host.

## Changes
### openSUSE Leap 15.6 and 16
- `detect_distro`: accept `opensuse-leap` and bare `opensuse` as members of the SLES family (`DISTRO_FAMILY="sles"`).
- Bump `SCRIPT_VERSION` to `1.2.5`.

That single detection line is the only functional change required. Everything downstream already handles it, which I verified against the current script:

| Function | Why no change is needed |
|---|---|
| `set_package_manager` | Already normalises the whole SLES family to `DISTRO="sles"` with `zypper`. |
| `scale_version_id` | The `sles` family branch already maps `15*` → `15` and `16*` → `16` (the `16*` arm arrived with SLES 16 support in #246). |
| `verify_supported_distros` | Runs after `set_package_manager`, so it sees `sles` and already accepts major `15\|16`. |
| `install_on_sles` | Already imports the rotated `microsoft-2025.asc` when `VERSION` is `16*`, so Leap 16 picks up the correct key automatically. |

I deliberately kept the diff to the detection line rather than adding an openSUSE-specific version-scaling block, since that would only have duplicated the existing `15*`/`16*` arms.

These changes mirror the merged internal installer PRs (WD.Client.Linux.Installer 16104110 for Leap 15.6 and 16116836 for Leap 16).

## Testing
- `bash -n` clean and `shellcheck -S warning` clean (exit 0) on the patched script.
- Resolved routing verified for `opensuse-leap`/`opensuse` `15.6` and `16.0`: `DISTRO_FAMILY=sles`, `SCALED_VERSION=15`/`16`, `zypper`, `config/sles/15|16/<channel>.repo`, and `microsoft.asc` / `microsoft-2025.asc` respectively. Existing `sles`, `sles_sap`, `sle-hpc` `12.5`/`15.5`/`16.0` routing is byte-for-byte unchanged.
- Live check against packages.microsoft.com: `config/sles/15` and `config/sles/16` both serve `mdatp` for `x86_64` and `aarch64`, and their `.repo` files pin `microsoft.asc` and `microsoft-2025.asc` respectively — matching what the script imports.
- **openSUSE Leap 16.0, x86_64 and ARM64:** manual end-to-end validation on real VMs — installed from `config/sles/16`, onboarded (health reports healthy and licensed), EICAR, Behaviour-Monitoring and EDR connectivity checks all passed (internal PR 16116836).
- **openSUSE Leap 15.6:** covered by the internal ShellSpec installer suite and the routing verification above; automated CI-matrix coverage is tracked internally.
