### PR TITLE
macOS 27 EDLP accessibility settings to the plist/mobileconfig/schemas

### DIFF
--- a/macos/settings/data_loss_prevention/accessibility/com.microsoft.wdav.mobileconfig
+++ b/macos/settings/data_loss_prevention/accessibility/com.microsoft.wdav.mobileconfig
@@ -63,14 +63,14 @@
                         <key>enforcement</key>
                         <dict>
                             <key>unallowedBrowserMode</key>
-                            <string>audit</string>
+                            <string>enforce</string>
                             <key>pasteToBrowserMode</key>
                             <string>enforce</string>
                         </dict>
                         <key>notification</key>
                         <dict>
-                            <key>Please enable Accessibility permissions to comply with IT Policy</key>
-                            <string/>
+                            <key>customMessage</key>
+                            <string>Please enable Accessibility permissions to comply with IT Policy</string>
                         </dict>
                     </dict>
                 </dict>
@@ -78,4 +78,3 @@
         </array>
     </dict>
 </plist>
-

--- a/macos/settings/data_loss_prevention/accessibility/com.microsoft.wdav.plist
+++ b/macos/settings/data_loss_prevention/accessibility/com.microsoft.wdav.plist
@@ -14,14 +14,14 @@
         <key>enforcement</key>
         <dict>
           <key>unallowedBrowserMode</key>
-          <string>audit</string>
+          <string>enforce</string>
           <key>pasteToBrowserMode</key>
           <string>enforce</string>
         </dict>
         <key>notification</key>
         <dict>
-          <key>Please enable Accessibility permissions to comply with IT Policy</key>
-          <string/>
+          <key>customMessage</key>
+          <string>Please enable Accessibility permissions to comply with IT Policy</string>
         </dict>
       </dict>
     </dict>

--- a/macos/settings/data_loss_prevention/schema.json
+++ b/macos/settings/data_loss_prevention/schema.json
@@ -921,7 +921,7 @@
                                     "enum": ["off", "audit", "enforce"]
                                 },
                                 "pasteToBrowserMode": {
-                                     "title": "Restricted protection mode for paste to browser",
+                                    "title": "Restricted protection mode for paste to browser",
                                     "description": "Controls whether pasting sensitive content to non-Edge browsers is enforced or audited when Accessibility is off.",
                                     "propertyOrder": 20,
                                     "type": "string",


### PR DESCRIPTION
Adds macOS 27 Endpoint DLP accessibility settings to the Defender schemas, including enforcement modes for browser upload and paste operations plus a customizable notification message. Includes Intune/JAMF configuration examples and documentation.