### PR TITLE
Harden Linux scheduler crontab handling

### DIFF
--- a/linux/scheduler/README.md
+++ b/linux/scheduler/README.md
@@ -2,13 +2,29 @@
 
 Two scripts are available to help with creating cron tasks related to MDE.
 
+The scripts modify the crontab of the user who runs them. Sudo is not required
+for ordinary per-user scheduling. Running a script with sudo intentionally
+modifies root's crontab.
+
+Both scripts preserve existing entries and append a new entry each time they
+run, including when an identical entry already exists. They install the updated
+crontab through standard input using `crontab -`; this is supported by Cronie
+and Debian/Vixie-derived cron implementations and does not depend on the Linux
+kernel version.
+
+Use `--backup PATH` to save the previous crontab before installing the new
+entry. The backup is created as a new file with permissions `0600`. For safety,
+the command fails without modifying the crontab if the path already exists or
+the backup cannot be written. Choose a path in a directory trusted by the user
+running the script. Restore a backup manually with `crontab PATH`.
+
 ## schedule_scan.py
 
 This script creates a cron job that will perform virus scans on the desired schedule.
 
 ### Usage 
 
-`$python3 schedule_scan.py [-h] [-H {0-23}] [-D {*,0-6}] [-S {quick,full}] [-L LOG_FILE] [-d]`
+`$ python3 schedule_scan.py [-h] [-H {0-23}] [-D {*,0-6}] [-S {quick,full}] [-L LOG_FILE] [--backup PATH] [-d]`
 
 ### Options
 
@@ -19,6 +35,7 @@ This script creates a cron job that will perform virus scans on the desired sche
 | -D {*,0-6}, --day {*,0-6} | A Number representing the day of the week: 0 => Sunday, 6 => Saturday or * to represent every day. | * (everyday) |
 | -S {quick,full}, --scan {quick,full} | Type of scan to run ('quick' or 'full'). | quick |
 | -L LOG_FILE, --log LOG_FILE | Log file name and location for output. | /tmp/mdatp_scheduled_scan.log |
+| --backup PATH | Save the current crontab to a new `0600` file before making changes. | No backup |
 | -d, --debug | dump script parameters and print debug statements. No actions will be taken | |
 
 ## schedule_update.py
@@ -27,7 +44,7 @@ This script creates a cron job that will perform MDE package updates on the desi
 
 ### Usage: 
 
-`$python3 schedule_update.py [-h] [-H {0-23}] [-D {0-6}] [-O {RHEL,SLES,DEB}] [-L LOG_FILE] [-d]`
+`$ python3 schedule_update.py [-h] [-H {0-23}] [-D {0-6}] [-O {RHEL,SLES,DEB}] [-L LOG_FILE] [--backup PATH] [-d]`
 
 ### Options
 
@@ -38,4 +55,5 @@ This script creates a cron job that will perform MDE package updates on the desi
 | -D {0-6}, --day {0-6} | A number that represents the day of the week: 0 => Sunday, 6 => Saturday. Everyday ('*') is not allowed as checking for updates daily is not recommended. | 6 (SAT) | 
 | -O {RHEL,SLES,DEB}, --os {RHEL,SLES,DEB} | Linux Distribution | DEB |
 | -L LOG_FILE, --log LOG_FILE | Log file location for output. | /tmp/mdatp_update_job.log |
+| --backup PATH | Save the current crontab to a new `0600` file before making changes. | No backup |
 | -d, --debug | dump parameters | |

--- a/linux/scheduler/README.md
+++ b/linux/scheduler/README.md
@@ -16,7 +16,8 @@ Use `--backup PATH` to save the previous crontab before installing the new
 entry. The backup is created as a new file with permissions `0600`. For safety,
 the command fails without modifying the crontab if the path already exists or
 the backup cannot be written. Choose a path in a directory trusted by the user
-running the script. Restore a backup manually with `crontab PATH`.
+running the script. Restore a user backup with `crontab PATH`, or restore a
+root backup with `sudo crontab PATH`.
 
 ## schedule_scan.py
 

--- a/linux/scheduler/README.md
+++ b/linux/scheduler/README.md
@@ -43,6 +43,11 @@ This script creates a cron job that will perform virus scans on the desired sche
 
 This script creates a cron job that will perform MDE package updates on the desired schedule.
 
+The generated update command uses `sudo`. When this script is run without sudo,
+the scheduled user must have non-interactive sudo permission for the selected
+package-manager command; cron cannot respond to a password prompt. Running the
+script with sudo installs the entry in root's crontab instead.
+
 ### Usage: 
 
 `$ python3 schedule_update.py [-h] [-H {0-23}] [-D {0-6}] [-O {RHEL,SLES,DEB}] [-L LOG_FILE] [--backup PATH] [-d]`

--- a/linux/scheduler/cron_utils.py
+++ b/linux/scheduler/cron_utils.py
@@ -8,6 +8,21 @@ class CronError(Exception):
     pass
 
 
+def _remove_incomplete_backup(backup_path):
+    try:
+        os.unlink(backup_path)
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        return error
+    return None
+
+
+def _validate_cron_expression(cron_expression):
+    if "\n" in cron_expression or "\r" in cron_expression:
+        raise CronError("Cron expression must contain exactly one line.")
+
+
 def get_current_crontab():
     env = os.environ.copy()
     env["LC_ALL"] = "C"
@@ -43,19 +58,33 @@ def write_crontab_backup(backup_path, current_crontab):
         raise CronError(f"Failed to create backup '{backup_path}': {error}") from error
 
     try:
-        with os.fdopen(file_descriptor, "wb") as backup_file:
+        backup_file = os.fdopen(file_descriptor, "wb")
+    except OSError as error:
+        cleanup_errors = []
+        try:
+            os.close(file_descriptor)
+        except OSError as close_error:
+            cleanup_errors.append(f"failed to close backup: {close_error}")
+
+        unlink_error = _remove_incomplete_backup(backup_path)
+        if unlink_error:
+            cleanup_errors.append(
+                f"failed to remove incomplete backup '{backup_path}': {unlink_error}"
+            )
+
+        error_message = f"Failed to open backup '{backup_path}': {error}"
+        if cleanup_errors:
+            error_message += "; " + "; ".join(cleanup_errors)
+        raise CronError(error_message) from error
+
+    try:
+        with backup_file:
             os.fchmod(backup_file.fileno(), 0o600)
             backup_file.write(current_crontab)
             backup_file.flush()
             os.fsync(backup_file.fileno())
     except OSError as error:
-        cleanup_error = None
-        try:
-            os.unlink(backup_path)
-        except FileNotFoundError:
-            pass
-        except OSError as unlink_error:
-            cleanup_error = unlink_error
+        cleanup_error = _remove_incomplete_backup(backup_path)
 
         error_message = f"Failed to write backup '{backup_path}': {error}"
         if cleanup_error:
@@ -67,6 +96,8 @@ def write_crontab_backup(backup_path, current_crontab):
 
 
 def append_cron_entry(current_crontab, cron_expression):
+    _validate_cron_expression(cron_expression)
+
     separator = b"" if not current_crontab or current_crontab.endswith(b"\n") else b"\n"
     return (
         current_crontab
@@ -100,8 +131,10 @@ def install_crontab(crontab_content):
 
 
 def add_cron_entry(cron_expression, backup_path=None):
+    _validate_cron_expression(cron_expression)
     current_crontab = get_current_crontab()
+    updated_crontab = append_cron_entry(current_crontab, cron_expression)
     if backup_path is not None:
         write_crontab_backup(backup_path, current_crontab)
 
-    install_crontab(append_cron_entry(current_crontab, cron_expression))
+    install_crontab(updated_crontab)

--- a/linux/scheduler/cron_utils.py
+++ b/linux/scheduler/cron_utils.py
@@ -42,22 +42,28 @@ def write_crontab_backup(backup_path, current_crontab):
     except OSError as error:
         raise CronError(f"Failed to create backup '{backup_path}': {error}") from error
 
-    backup_complete = False
     try:
         with os.fdopen(file_descriptor, "wb") as backup_file:
             os.fchmod(backup_file.fileno(), 0o600)
             backup_file.write(current_crontab)
             backup_file.flush()
             os.fsync(backup_file.fileno())
-        backup_complete = True
     except OSError as error:
-        raise CronError(f"Failed to write backup '{backup_path}': {error}") from error
-    finally:
-        if not backup_complete:
-            try:
-                os.unlink(backup_path)
-            except FileNotFoundError:
-                pass
+        cleanup_error = None
+        try:
+            os.unlink(backup_path)
+        except FileNotFoundError:
+            pass
+        except OSError as unlink_error:
+            cleanup_error = unlink_error
+
+        error_message = f"Failed to write backup '{backup_path}': {error}"
+        if cleanup_error:
+            error_message += (
+                f"; failed to remove incomplete backup '{backup_path}': "
+                f"{cleanup_error}"
+            )
+        raise CronError(error_message) from error
 
 
 def append_cron_entry(current_crontab, cron_expression):
@@ -95,7 +101,7 @@ def install_crontab(crontab_content):
 
 def add_cron_entry(cron_expression, backup_path=None):
     current_crontab = get_current_crontab()
-    if backup_path:
+    if backup_path is not None:
         write_crontab_backup(backup_path, current_crontab)
 
     install_crontab(append_cron_entry(current_crontab, cron_expression))

--- a/linux/scheduler/cron_utils.py
+++ b/linux/scheduler/cron_utils.py
@@ -77,22 +77,35 @@ def write_crontab_backup(backup_path, current_crontab):
             error_message += "; " + "; ".join(cleanup_errors)
         raise CronError(error_message) from error
 
+    write_error = None
+    cleanup_errors = []
     try:
-        with backup_file:
-            os.fchmod(backup_file.fileno(), 0o600)
-            backup_file.write(current_crontab)
-            backup_file.flush()
-            os.fsync(backup_file.fileno())
+        os.fchmod(backup_file.fileno(), 0o600)
+        backup_file.write(current_crontab)
+        backup_file.flush()
+        os.fsync(backup_file.fileno())
     except OSError as error:
-        cleanup_error = _remove_incomplete_backup(backup_path)
+        write_error = error
 
-        error_message = f"Failed to write backup '{backup_path}': {error}"
+    try:
+        backup_file.close()
+    except OSError as close_error:
+        if write_error is None:
+            write_error = close_error
+        else:
+            cleanup_errors.append(f"failed to close backup: {close_error}")
+
+    if write_error is not None:
+        cleanup_error = _remove_incomplete_backup(backup_path)
         if cleanup_error:
-            error_message += (
-                f"; failed to remove incomplete backup '{backup_path}': "
-                f"{cleanup_error}"
+            cleanup_errors.append(
+                f"failed to remove incomplete backup '{backup_path}': {cleanup_error}"
             )
-        raise CronError(error_message) from error
+
+        error_message = f"Failed to write backup '{backup_path}': {write_error}"
+        if cleanup_errors:
+            error_message += "; " + "; ".join(cleanup_errors)
+        raise CronError(error_message) from write_error
 
 
 def append_cron_entry(current_crontab, cron_expression):

--- a/linux/scheduler/cron_utils.py
+++ b/linux/scheduler/cron_utils.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+
+class CronError(Exception):
+    pass
+
+
+def get_current_crontab():
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"
+
+    try:
+        result = subprocess.run(
+            ["crontab", "-l"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+    except OSError as error:
+        raise CronError(f"Failed to list the current crontab: {error}") from error
+
+    if result.returncode == 0:
+        return result.stdout
+
+    error_message = result.stderr.decode("utf-8", errors="replace").strip()
+    if result.returncode == 1 and error_message.lower().startswith("no crontab for "):
+        return b""
+
+    raise CronError(
+        f"Failed to list the current crontab: {error_message or 'unknown error'}"
+    )
+
+
+def write_crontab_backup(backup_path, current_crontab):
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+
+    try:
+        file_descriptor = os.open(backup_path, flags, 0o600)
+    except OSError as error:
+        raise CronError(f"Failed to create backup '{backup_path}': {error}") from error
+
+    backup_complete = False
+    try:
+        with os.fdopen(file_descriptor, "wb") as backup_file:
+            os.fchmod(backup_file.fileno(), 0o600)
+            backup_file.write(current_crontab)
+            backup_file.flush()
+            os.fsync(backup_file.fileno())
+        backup_complete = True
+    except OSError as error:
+        raise CronError(f"Failed to write backup '{backup_path}': {error}") from error
+    finally:
+        if not backup_complete:
+            try:
+                os.unlink(backup_path)
+            except FileNotFoundError:
+                pass
+
+
+def append_cron_entry(current_crontab, cron_expression):
+    separator = b"" if not current_crontab or current_crontab.endswith(b"\n") else b"\n"
+    return (
+        current_crontab
+        + separator
+        + cron_expression.encode("utf-8")
+        + b"\n"
+    )
+
+
+def install_crontab(crontab_content):
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"
+
+    try:
+        result = subprocess.run(
+            ["crontab", "-"],
+            input=crontab_content,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+    except OSError as error:
+        raise CronError(f"Failed to install the updated crontab: {error}") from error
+
+    if result.returncode != 0:
+        error_message = result.stderr.decode("utf-8", errors="replace").strip()
+        raise CronError(
+            f"Failed to install the updated crontab: "
+            f"{error_message or 'unknown error'}"
+        )
+
+
+def add_cron_entry(cron_expression, backup_path=None):
+    current_crontab = get_current_crontab()
+    if backup_path:
+        write_crontab_backup(backup_path, current_crontab)
+
+    install_crontab(append_cron_entry(current_crontab, cron_expression))

--- a/linux/scheduler/schedule_scan.py
+++ b/linux/scheduler/schedule_scan.py
@@ -23,7 +23,7 @@ def create_cron_job(
     if debug:
         print(f"[d] cron_expression: {cron_expression}")
         print("[d] list_command: crontab -l")
-        if backup_path:
+        if backup_path is not None:
             print(f"[d] backup_path: {backup_path}")
         print("[d] install_command: crontab -")
     else:

--- a/linux/scheduler/schedule_scan.py
+++ b/linux/scheduler/schedule_scan.py
@@ -1,61 +1,34 @@
 #!/usr/bin/env python3
 
-import os
 import argparse
-from datetime import datetime
+import sys
 
-def backup_cron_jobs(debug):
-    try:
-        today = datetime.today().date()
-        formatted_date = today.strftime('%Y%m%d')
-        backup_location = f"/tmp/cron_schedule_scan_backup_{formatted_date}"
+from cron_utils import CronError, add_cron_entry
 
-        cron_backup = f"(crontab -l > {backup_location})"
-        if debug == True:
-            print(f"[d]cron_backup: {cron_backup}")
-        else:
-            os.system(cron_backup)
-    except Exception as e:
-        print(f"[!] Error performing cron backup: {e}")
-        raise Exception("Error attempting to backup cron jobs.")
 
-def create_cron_job(minute="*", 
-                    hour="2", 
-                    day_of_month="*", 
-                    month="*", 
-                    day_of_week="*", 
-                    command="/bin/mdatp scan quick > /tmp/mdatp_scheduled_scan.log", 
-                    debug=False):
-    
-    today = datetime.today().date()
-    formatted_date = today.strftime('%Y%m%d')
-    export_file = f"/tmp/cron_scan_schedule_{formatted_date}"
+def create_cron_job(
+    minute="*",
+    hour="2",
+    day_of_month="*",
+    month="*",
+    day_of_week="*",
+    command="/bin/mdatp scan quick > /tmp/mdatp_scheduled_scan.log",
+    debug=False,
+    backup_path=None,
+):
+    cron_expression = (
+        f"{minute} {hour} {day_of_month} {month} {day_of_week} {command}"
+    )
 
-    # Construct the cron task expression
-    cron_expression = f"{minute} {hour} {day_of_month} {month} {day_of_week} {command}"
-    
-    # pull cron tasks, append cron_expression, and store in tmp file
-    cron_export = f"crontab -l > {export_file}"
-    cron_append_task = f"echo '{cron_expression}' >> {export_file}"
-
-    # push cron task temp file back to crontab for loading
-    cron_cmd = f"crontab {export_file}"
-
-    if debug == True:
+    if debug:
         print(f"[d] cron_expression: {cron_expression}")
-        print(f"[d] cron_export: {cron_export}")
-        print(f"[d] task_append_cmd: {cron_append_task}")
-        print(f"[d] cron_cmd: {cron_cmd}")
+        print("[d] list_command: crontab -l")
+        if backup_path:
+            print(f"[d] backup_path: {backup_path}")
+        print("[d] install_command: crontab -")
     else:
-        try:
-            # Add the command to the crontab
-            os.system(cron_export)
-            os.system(cron_append_task)
-            os.system(cron_cmd)
-            print(f"Cron job added successfully: {cron_expression}")
-        except Exception as e:
-            print(f"[!] Error adding cron job: {e}")
-            raise Exception("Error attempting to create cron job.")
+        add_cron_entry(cron_expression, backup_path)
+        print(f"Cron job added successfully: {cron_expression}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="This script creates a cron job that will perform virus scans on the desired schedule.")
@@ -88,18 +61,26 @@ if __name__ == "__main__":
         dest="debug",
         default=False,
         help="dump parameters")
-    
+    parser.add_argument("--backup",
+        action="store",
+        dest="backup_path",
+        help="Save the current crontab to a new file before installing the updated crontab.")
+
     try:
         args = parser.parse_args()
         cmd_string = f"/bin/mdatp scan {args.scan_type} > {args.log_file}"
-        if args.debug == True:
+        if args.debug:
             print(f"[d] Hour: {args.hour} Day: {args.day} Cmd: {cmd_string}")
 
-        backup_cron_jobs(args.debug)
-        create_cron_job(hour=args.hour, day_of_week=args.day, command=cmd_string, debug=args.debug)
-    
+        create_cron_job(
+            hour=args.hour,
+            day_of_week=args.day,
+            command=cmd_string,
+            debug=args.debug,
+            backup_path=args.backup_path,
+        )
     except KeyboardInterrupt:
-        quit()
-    except Exception as e:
-        print(f"[!] schedule_scan script failed: {e}")
-        quit()
+        sys.exit(130)
+    except CronError as error:
+        print(f"[!] schedule_scan script failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/linux/scheduler/schedule_update.py
+++ b/linux/scheduler/schedule_update.py
@@ -23,7 +23,7 @@ def create_cron_job(
     if debug:
         print(f"[d] cron_expression: {cron_expression}")
         print("[d] list_command: crontab -l")
-        if backup_path:
+        if backup_path is not None:
             print(f"[d] backup_path: {backup_path}")
         print("[d] install_command: crontab -")
     else:

--- a/linux/scheduler/schedule_update.py
+++ b/linux/scheduler/schedule_update.py
@@ -1,62 +1,34 @@
 #!/usr/bin/env python3
 
-import os
 import argparse
-from datetime import datetime
-    
-def backup_cron_jobs(debug):
-    try:
-        today = datetime.today().date()
-        formatted_date = today.strftime('%Y%m%d')
-        backup_location = f"/tmp/cron_schedule_update_backup_{formatted_date}"
+import sys
 
-        cron_backup = f"(crontab -l > {backup_location})"
-        if debug == True:
-            print(f"[d] cron_backup: {cron_backup}")
-        else:
-            os.system(cron_backup)
-    except Exception as e:
-        print(f"[!] Error performing cron backup: {e}")
-        raise Exception("Error attempting to backup cron jobs.")
+from cron_utils import CronError, add_cron_entry
 
-def create_cron_job(minute="*", 
-                    hour="2", 
-                    day_of_month="*", 
-                    month="*", 
-                    day_of_week="6", 
-                    command="", 
-                    debug=False):
-    
-    today = datetime.today().date()
-    formatted_date = today.strftime('%Y%m%d')
-    export_file = f"/tmp/cron_update_schedule_{formatted_date}"
 
-    # Construct the cron task expression
-    cron_expression = f"{minute} {hour} {day_of_month} {month} {day_of_week} {command}"
-    
-    # pull cron tasks, append cron_expression, and store in tmp file
-    cron_export = f"crontab -l > {export_file}"
-    cron_append_task = f"echo '{cron_expression}' >> {export_file}"
+def create_cron_job(
+    minute="*",
+    hour="2",
+    day_of_month="*",
+    month="*",
+    day_of_week="6",
+    command="",
+    debug=False,
+    backup_path=None,
+):
+    cron_expression = (
+        f"{minute} {hour} {day_of_month} {month} {day_of_week} {command}"
+    )
 
-    # push cron task temp file back to crontab for loading
-    cron_cmd = f"crontab {export_file}"
-
-    if debug == True:
+    if debug:
         print(f"[d] cron_expression: {cron_expression}")
-        print(f"[d] cron_export: {cron_export}")
-        print(f"[d] task_append_cmd: {cron_append_task}")
-        print(f"[d] cron_cmd: {cron_cmd}")
+        print("[d] list_command: crontab -l")
+        if backup_path:
+            print(f"[d] backup_path: {backup_path}")
+        print("[d] install_command: crontab -")
     else:
-        try:
-            # Add the command to the crontab
-            os.system(cron_export)
-            os.system(cron_append_task)
-            os.system(cron_cmd)
-
-            print(f"Cron job added successfully: {cron_expression}")
-        except Exception as e:
-            print(f"[!] Error adding cron job: {e}")
-            raise Exception("Error attempting to create cron job.")
+        add_cron_entry(cron_expression, backup_path)
+        print(f"Cron job added successfully: {cron_expression}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="This script creates a cron job that will perform MDE package updates on the desired schedule.")
@@ -89,22 +61,30 @@ if __name__ == "__main__":
         dest="debug",
         default=False,
         help="dump parameters")
-    
+    parser.add_argument("--backup",
+        action="store",
+        dest="backup_path",
+        help="Save the current crontab to a new file before installing the updated crontab.")
+
     try:
         args = parser.parse_args()
         update_dict = {"RHEL":"yum update mdatp -y",
                        "SLES":"zypper update mdatp",
                        "DEB":"apt install --only-upgrade mdatp"}
-        
+
         cmd_string = f"sudo {update_dict[args.os]} >> {args.log_file}"
-        if args.debug == True:
+        if args.debug:
             print(f"[d] Hour: {args.hour} Day: {args.day} Cmd: {cmd_string}")
 
-        backup_cron_jobs(args.debug)
-        create_cron_job(hour=args.hour, day_of_week=args.day, command=cmd_string, debug=args.debug)
-    
+        create_cron_job(
+            hour=args.hour,
+            day_of_week=args.day,
+            command=cmd_string,
+            debug=args.debug,
+            backup_path=args.backup_path,
+        )
     except KeyboardInterrupt:
-        quit()
-    except Exception as e:
-        print(f"[!] schedule_scan script failed: {e}")
-        quit()
+        sys.exit(130)
+    except CronError as error:
+        print(f"[!] schedule_update script failed: {error}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Harden the Linux scan and update scheduler scripts by removing predictable
temporary crontab files and shell-based crontab manipulation.

## Changes

- Add shared checked crontab operations in `cron_utils.py`.
- Read the invoking user's existing crontab without a shell.
- Install updated crontabs through `crontab -` standard input.
- Preserve existing entries and the current duplicate-entry behavior.
- Add optional `--backup PATH` support:
  - Creates a new file exclusively.
  - Uses mode `0600`.
  - Saves the exact prior crontab.
  - Aborts before installation if backup creation or writing fails.
- Return nonzero and avoid printing success when listing, backup, or
  installation fails.
- Document user-versus-root behavior, backups, restoration, and cron
  compatibility.

## Testing

### Automated and isolated

- Passed Python compilation for `cron_utils.py`, `schedule_scan.py`, and
  `schedule_update.py`.
- Passed both scripts' `--help` and `--debug` paths.
- Passed `git diff --check`.
- Passed isolated user/root tests covering:
  - Existing and empty crontabs.
  - Standard-input installation.
  - Duplicate entries.
  - Listing and installation failures.
  - Success-message suppression on failure.
  - Removal of the former predictable `/tmp/cron_*` files.
- Completed a read-only code-review pass with no significant findings.

### Ubuntu real-spool end-to-end

Environment:

- Ubuntu 22.04
- `cron 3.0pl1-137ubuntu3`
- Real user and root crontab spools; no shim

Verified:

- User and root installation through standard input.
- Preservation of existing entries.
- Exact prior-crontab backup contents.
- User and root backup mode `0600`, with root ownership for the root backup.
- Existing-path and symlink rejection before crontab modification.
- Missing-parent backup failure before installation.
- Operation without a backup.
- Duplicate appends.
- Debug-mode no-op behavior.
- Restoration of the original user and root crontab states.

### Amazon Linux Cronie real-spool end-to-end

Environment:

- Amazon Linux 2023.12
- `cronie 1.5.7-1.amzn2023.0.2`
- Python 3.9.25
- Real user and root crontab spools; no shim

The provided test host was Amazon Linux 2023 rather than Amazon Linux 2. This
validates the Cronie implementation family, but not AL2's exact Cronie package
version.

Verified:

- Empty and existing user crontabs.
- User and root installation through standard input.
- Exact empty and non-empty backup contents.
- Backup mode and ownership.
- Existing-path, symlink, and missing-parent backup failures.
- No-backup and duplicate-entry behavior.
- Debug-mode no-op behavior.
- Cronie rejection of an invalid expression without changing the prior
  crontab.
- Restoration of the original user and root crontab states.
