### PR TITLE
Harden Linux Client Analyzer handoff with private workspaces

### DIFF
--- a/linux/LiveResponse/ClientAnalyzer/InstallXMDEClientAnalyzer.sh
+++ b/linux/LiveResponse/ClientAnalyzer/InstallXMDEClientAnalyzer.sh
@@ -1,28 +1,15 @@
-#! /usr/bin/bash
-echo "Starting Client Analyzer Script. Running As:"
-whoami
+#!/bin/sh
+set -eu
 
-echo "Getting XMDEClientAnalyzerBinary"
-wget --quiet -O /tmp/XMDEClientAnalyzerBinary.zip https://go.microsoft.com/fwlink/?linkid=2297517
-if [ $? -ne 0 ]; then
-    echo 'ERROR: wget failed to retrieve XMDEClientAnalyzerBinary.zip exiting!'
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+script_directory=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+helper="$script_directory/client_analyzer_handoff.py"
+
+if [ ! -f "$helper" ] || [ -L "$helper" ]; then
+    echo "ERROR: Client Analyzer package is incomplete." >&2
     exit 1
-fi  
-echo '9D0552DBBD1693D2E2ED55F36147019CFECFDC009E76BAC4186CF03CD691B469 /tmp/XMDEClientAnalyzerBinary.zip' | sha256sum -c
-
-
-echo "Unzipping XMDEClientAnalyzerBinary.zip"
-unzip -q /tmp/XMDEClientAnalyzerBinary.zip -d /tmp/XMDEClientAnalyzerBinary
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to unzip the XMDEClientAnalyzerBinary.zip in /tmp to /tmp/XMDEClientAnalyzerBinary"
-    exit 2
 fi
 
-
-echo "Unzipping SupportToolLinuxBinary.zip"
-unzip -q /tmp/XMDEClientAnalyzerBinary/SupportToolLinuxBinary.zip -d /tmp/XMDEClientAnalyzerBinary/ClientAnalyzer
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to unzip the SupportToolLinuxBinary.zip file in /tmp/XMDEClientAnalyzerBinary to /tmp/XMDEClientAnalyzerBinary/ClientAnalyzer"
-    exit 3
-fi
-echo "MDESupportTool installed at /tmp/XMDEClientAnalyzerBinary/ClientAnalyzer"
+exec python3 "$helper" install-binary "$@"

--- a/linux/LiveResponse/ClientAnalyzer/InstallXMDEPythonClientAnalyzer.sh
+++ b/linux/LiveResponse/ClientAnalyzer/InstallXMDEPythonClientAnalyzer.sh
@@ -1,20 +1,15 @@
-#! /usr/bin/bash
+#!/bin/sh
+set -eu
 
-wget --quiet -O /tmp/XMDEClientAnalyzer.zip https://aka.ms/XMDEClientAnalyzer
-if [ $? -ne 0 ]; then
-    echo 'ERROR: wget failed to retrieve XMDEClientAnalyzerBinary.zip exiting!'
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+script_directory=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+helper="$script_directory/client_analyzer_handoff.py"
+
+if [ ! -f "$helper" ] || [ -L "$helper" ]; then
+    echo "ERROR: Client Analyzer package is incomplete." >&2
     exit 1
 fi
-echo '36C2B13AE657456119F3DC2A898FD9D354499A33F65015670CE2CD8A937F3C66 /tmp/XMDEClientAnalyzer.zip' | sha256sum -c
 
-unzip -q /tmp/XMDEClientAnalyzer.zip -d /tmp/XMDEClientAnalyzer
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to unzip the XMDEClientAnalyzerBinary.zip in /tmp to /tmp/XMDEClientAnalyzerBinary"
-    exit 2
-fi
-
-cd /tmp/XMDEClientAnalyzer
-chmod a+x mde_support_tool.sh
-
-echo 'Running final setup script /tmp/XMDEClientAnalyzer/mde_support_tool.sh'
-./mde_support_tool.sh
+exec python3 "$helper" install-python "$@"

--- a/linux/LiveResponse/ClientAnalyzer/MDEPythonSupportTool.sh
+++ b/linux/LiveResponse/ClientAnalyzer/MDEPythonSupportTool.sh
@@ -1,4 +1,15 @@
-#! /usr/bin/bash
+#!/bin/sh
+set -eu
 
-cd /tmp/XMDEClientAnalyzer
-./mde_support_tool.sh -d $@
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+script_directory=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+helper="$script_directory/client_analyzer_handoff.py"
+
+if [ ! -f "$helper" ] || [ -L "$helper" ]; then
+    echo "ERROR: Client Analyzer package is incomplete." >&2
+    exit 1
+fi
+
+exec python3 "$helper" run-python "$@"

--- a/linux/LiveResponse/ClientAnalyzer/MDESupportTool.sh
+++ b/linux/LiveResponse/ClientAnalyzer/MDESupportTool.sh
@@ -1,7 +1,15 @@
-#! /usr/bin/bash
+#!/bin/sh
+set -eu
 
-echo "cd /tmp/XMDEClientAnalyzerBinary/ClientAnalyzer"
-cd /tmp/XMDEClientAnalyzerBinary/ClientAnalyzer
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
 
-echo "Running MDESupportTool"
-./MDESupportTool $@
+script_directory=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+helper="$script_directory/client_analyzer_handoff.py"
+
+if [ ! -f "$helper" ] || [ -L "$helper" ]; then
+    echo "ERROR: Client Analyzer package is incomplete." >&2
+    exit 1
+fi
+
+exec python3 "$helper" run-binary "$@"

--- a/linux/LiveResponse/ClientAnalyzer/README.md
+++ b/linux/LiveResponse/ClientAnalyzer/README.md
@@ -1,7 +1,70 @@
 # Live Response: Client Analyzer
 
-These scripts provide a way to install and run the client analyzer, Binary and Python versions, on a Linux endpoint during a live response session. 
+These actions install and run the binary or Python Client Analyzer in a private workspace during a Microsoft Defender for Endpoint Live Response session.
 
-## How to use these scripts
+## Requirements
 
-Please refer to the [Microsoft Learn: Run the client analyzer on Linux]() documentation for a reference of how to use these scripts.
+- The installer and matching runner must execute as the same operating-system user.
+- The complete `ClientAnalyzer` directory must remain together so the wrappers can load `client_analyzer_handoff.py`.
+- `curl`, `mktemp`, `sha256sum`, `stat`, and `unzip` must be available.
+- The endpoint must be able to reach the Microsoft download endpoint.
+- Retrieve generated diagnostic archives before the private workspace is removed.
+
+The workspace is created under `/var/tmp` with a random name and `0700` permissions. `/var/tmp` can be cleaned by local policy, so rerun the installer if a saved workspace is no longer available.
+
+## Binary Client Analyzer
+
+Upload `client_analyzer_handoff.py`, `InstallXMDEClientAnalyzer.sh`, and `MDESupportTool.sh`.
+
+Run the installer without parameters:
+
+```text
+run InstallXMDEClientAnalyzer.sh
+```
+
+Copy the printed workspace ID and pass only that ID to the runner:
+
+```text
+run MDESupportTool.sh -parameters "mde-client-analyzer-binary-{16 characters}"
+```
+
+The installer selects and verifies the amd64 or arm64 package.
+
+## Python Client Analyzer
+
+Upload `client_analyzer_handoff.py`, `InstallXMDEPythonClientAnalyzer.sh`, and `MDEPythonSupportTool.sh`.
+
+Run the installer without parameters:
+
+```text
+run InstallXMDEPythonClientAnalyzer.sh
+```
+
+Pass the printed workspace ID to the runner:
+
+```text
+run MDEPythonSupportTool.sh -parameters "mde-client-analyzer-python-{16 characters}"
+```
+
+The installer runs the package's existing dependency preparation before publishing the workspace.
+
+## Security Model
+
+- Workspaces are random, private, and inaccessible to a different local user.
+- Downloads require HTTPS for both the initial URL and redirects.
+- Outer, architecture-specific inner, and entrypoint SHA-256 values fail closed.
+- A `0600` completion record is written only after installation succeeds.
+- Runners validate token format, ownership, permissions, link counts, completion content, and entrypoint hashes.
+- Runners use fixed `--bypass-disclaimer -d` arguments instead of forwarding an unspecified Live Response parameter string.
+- Incomplete workspaces are removed after ordinary failures, HUP, INT, or TERM.
+
+The implementation trusts the internal structure of an artifact after its exact pinned hash matches. Network integrity tests audit the current published ZIP paths, file types, sizes, architecture archives, and entrypoint hashes. The shared helper centralizes this handoff logic while the existing action names remain unchanged. Same-UID and root attackers remain outside this protection boundary.
+
+## Validation
+
+```text
+python3 linux/LiveResponse/ClientAnalyzer/tests/test_minimal_client_analyzer_handoff.py -v
+RUN_NETWORK_INTEGRITY_TESTS=1 python3 linux/LiveResponse/ClientAnalyzer/tests/test_minimal_client_analyzer_handoff.py -v
+```
+
+For the broader product workflow, see [Run the Microsoft Defender for Endpoint Client Analyzer on Linux](https://learn.microsoft.com/en-us/defender-endpoint/run-analyzer-linux).

--- a/linux/LiveResponse/ClientAnalyzer/client_analyzer_handoff.py
+++ b/linux/LiveResponse/ClientAnalyzer/client_analyzer_handoff.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+
+import hashlib
+import os
+import platform
+import pwd
+import re
+import secrets
+import signal
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+STATE_PARENT = Path("/var/tmp")
+CHUNK_BYTES = 1024 * 1024
+ARCH_ALIASES = {
+    "x86_64": "amd64",
+    "amd64": "amd64",
+    "aarch64": "arm64",
+    "arm64": "arm64",
+}
+CONFIGS = {
+    "binary": {
+        "download_url": "https://go.microsoft.com/fwlink/?linkid=2336125",
+        "outer_sha256": "5f906591d33d675f14d73d5b658a796cec7480b023b18d45c5d687713a4d4fbb",
+        "workspace_prefix": "mde-client-analyzer-binary-",
+        "entrypoint": "MDESupportTool",
+        "archives": {
+            "amd64": {
+                "inner_name": "SupportToolLinuxamd64Binary.zip",
+                "inner_sha256": "a500c00fe0dc2bb5b23ec9c771fd40694d111fa78d095d6ff77e4f0b36a23903",
+                "entry_sha256": "b6b21fbc12b6d37be331a5e27a9741b43d35876645e02b26c8cafc4e623ed5e1",
+            },
+            "arm64": {
+                "inner_name": "SupportToolLinuxarm64Binary.zip",
+                "inner_sha256": "ba8cc0c9766f5c937a90db00af6ed936ecdbfbba88049a383df814203af5066a",
+                "entry_sha256": "a3b60a11eea093f9ec7b9bd7ea86a0e8bbc6f481116311dd678d69def49b5169",
+            },
+        },
+    },
+    "python": {
+        "download_url": "https://go.microsoft.com/fwlink/?linkid=2336046",
+        "outer_sha256": "0b7c350a1c19e049416b1c8fb7ed857569ddcc32fb90453a3fccd083487c0b4e",
+        "workspace_prefix": "mde-client-analyzer-python-",
+        "entrypoint": "mde_support_tool.sh",
+        "entry_sha256": "00a03ca9b9f9c6d985ef48f8bcaae5cd08b37af551a452d005847d612fb67ffe",
+    },
+}
+REMOVED_ENVIRONMENT_VARIABLES = (
+    "BASH_ENV",
+    "CDPATH",
+    "ENV",
+    "GLOBIGNORE",
+    "LD_AUDIT",
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "PYTHON",
+    "PYTHONHOME",
+    "PYTHONNOUSERSITE",
+    "PYTHONPATH",
+    "VIRTUAL_ENV",
+)
+
+
+class HandoffError(Exception):
+    pass
+
+
+def validate_state_parent():
+    parent_stat = os.lstat(STATE_PARENT)
+    if not stat.S_ISDIR(parent_stat.st_mode):
+        raise HandoffError(f"State parent is not a directory: {STATE_PARENT}")
+    mode = stat.S_IMODE(parent_stat.st_mode)
+    euid = os.geteuid()
+    private_parent = parent_stat.st_uid == euid and mode & 0o022 == 0
+    sticky_shared_parent = (
+        parent_stat.st_uid == 0
+        and mode & stat.S_ISVTX != 0
+        and mode & 0o002 != 0
+    )
+    if not private_parent and not sticky_shared_parent:
+        raise HandoffError(f"State parent is not trusted: {STATE_PARENT}")
+
+
+def validate_directory(path):
+    value = os.lstat(path)
+    if (
+        not stat.S_ISDIR(value.st_mode)
+        or value.st_uid != os.geteuid()
+        or stat.S_IMODE(value.st_mode) != 0o700
+    ):
+        raise HandoffError(f"Directory is not private: {path}")
+
+
+def validate_file(path, expected_mode=None):
+    value = os.lstat(path)
+    if (
+        not stat.S_ISREG(value.st_mode)
+        or value.st_uid != os.geteuid()
+        or value.st_nlink != 1
+    ):
+        raise HandoffError(f"File is not private and regular: {path}")
+    if expected_mode is not None and stat.S_IMODE(value.st_mode) != expected_mode:
+        raise HandoffError(f"File has unsafe permissions: {path}")
+
+
+def create_private_directory(parent, prefix):
+    for _ in range(10):
+        path = parent / (prefix + secrets.token_hex(8))
+        try:
+            os.mkdir(path, 0o700)
+        except FileExistsError:
+            continue
+        validate_directory(path)
+        return path
+    raise HandoffError("Failed to allocate a unique private directory.")
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_sha256(path, expected, label):
+    if sha256_file(path) != expected:
+        raise HandoffError(f"{label} failed integrity verification.")
+
+
+def run_tool(arguments, label, **kwargs):
+    result = subprocess.run(arguments, check=False, **kwargs)
+    if result.returncode != 0:
+        raise HandoffError(f"{label} failed with exit code {result.returncode}.")
+
+
+def download_file(url, destination):
+    run_tool(
+        [
+            "curl",
+            "-q",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "=https",
+            "--max-redirs",
+            "5",
+            "--connect-timeout",
+            "30",
+            "--max-time",
+            "180",
+            "--max-filesize",
+            "67108864",
+            "--output",
+            str(destination),
+            url,
+        ],
+        "Client Analyzer download",
+    )
+    validate_file(destination, 0o600)
+
+
+def normalize_payload(payload):
+    for root, directories, files in os.walk(payload, followlinks=False):
+        root_path = Path(root)
+        validate_directory(root_path)
+        for name in directories:
+            path = root_path / name
+            if path.is_symlink():
+                raise HandoffError(f"Archive contains a link: {path}")
+            os.chmod(path, 0o700)
+        for name in files:
+            path = root_path / name
+            validate_file(path)
+            current_mode = stat.S_IMODE(os.lstat(path).st_mode)
+            os.chmod(path, 0o700 if current_mode & 0o111 else 0o600)
+
+
+def resolve_architecture(kind):
+    if kind == "python":
+        return "any", None
+    machine = platform.machine().lower()
+    architecture = ARCH_ALIASES.get(machine)
+    if architecture is None:
+        raise HandoffError(f"Unsupported architecture: {machine or 'unknown'}")
+    return architecture, CONFIGS["binary"]["archives"][architecture]
+
+
+def entrypoint_sha256(kind, archive_info):
+    if kind == "binary":
+        return archive_info["entry_sha256"]
+    return CONFIGS["python"]["entry_sha256"]
+
+
+def extract_payload(kind, archive_path, payload, archive_info, workspace):
+    os.mkdir(payload, 0o700)
+    if kind == "binary":
+        inner_archive = workspace / archive_info["inner_name"]
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+        file_descriptor = os.open(inner_archive, flags, 0o600)
+        with os.fdopen(file_descriptor, "wb") as output:
+            run_tool(
+                ["unzip", "-p", str(archive_path), archive_info["inner_name"]],
+                "Architecture-specific archive extraction",
+                stdout=output,
+            )
+        verify_sha256(
+            inner_archive,
+            archive_info["inner_sha256"],
+            "Architecture-specific archive",
+        )
+        run_tool(
+            ["unzip", "-tq", str(inner_archive)],
+            "Archive validation",
+            stdout=subprocess.DEVNULL,
+        )
+        run_tool(
+            ["unzip", "-q", str(inner_archive), "-d", str(payload)],
+            "Client Analyzer extraction",
+        )
+        inner_archive.unlink()
+    else:
+        run_tool(
+            ["unzip", "-tq", str(archive_path)],
+            "Archive validation",
+            stdout=subprocess.DEVNULL,
+        )
+        run_tool(
+            ["unzip", "-q", str(archive_path), "-d", str(payload)],
+            "Client Analyzer extraction",
+        )
+    normalize_payload(payload)
+
+
+def completion_record(kind, architecture, workspace_id, archive_info):
+    config = CONFIGS[kind]
+    inner_sha256 = archive_info["inner_sha256"] if archive_info else "-"
+    return (
+        " ".join(
+            (
+                "1",
+                kind,
+                architecture,
+                config["outer_sha256"],
+                inner_sha256,
+                entrypoint_sha256(kind, archive_info),
+                workspace_id,
+            )
+        )
+        + "\n"
+    )
+
+
+def write_completion_record(path, content):
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    file_descriptor = os.open(path, flags, 0o600)
+    with os.fdopen(file_descriptor, "w", encoding="utf-8") as output:
+        output.write(content)
+        output.flush()
+        os.fsync(output.fileno())
+
+
+def private_environment(temp_directory, python_action=False):
+    environment = os.environ.copy()
+    for name in REMOVED_ENVIRONMENT_VARIABLES:
+        environment.pop(name, None)
+    environment["HOME"] = pwd.getpwuid(os.geteuid()).pw_dir
+    environment["LANG"] = "C"
+    environment["LC_ALL"] = "C"
+    environment["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    environment["TMPDIR"] = str(temp_directory)
+    if python_action:
+        environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    return environment
+
+
+def prepare_python_dependencies(entrypoint, payload, workspace):
+    setup_directory = create_private_directory(workspace, "setup-")
+    try:
+        run_tool(
+            [str(entrypoint)],
+            "Client Analyzer dependency preparation",
+            cwd=str(payload),
+            env=private_environment(setup_directory, python_action=True),
+        )
+    finally:
+        if setup_directory.exists():
+            shutil.rmtree(setup_directory)
+    verify_sha256(
+        entrypoint,
+        CONFIGS["python"]["entry_sha256"],
+        "Client Analyzer entrypoint",
+    )
+
+
+def install(kind):
+    config = CONFIGS[kind]
+    validate_state_parent()
+    architecture, archive_info = resolve_architecture(kind)
+    workspace = None
+    completed = False
+    try:
+        workspace = create_private_directory(
+            STATE_PARENT,
+            config["workspace_prefix"],
+        )
+        archive_path = workspace / "client-analyzer.zip"
+        download_file(config["download_url"], archive_path)
+        verify_sha256(
+            archive_path,
+            config["outer_sha256"],
+            "Client Analyzer archive",
+        )
+
+        payload = workspace / "payload"
+        extract_payload(kind, archive_path, payload, archive_info, workspace)
+        archive_path.unlink()
+
+        entrypoint = payload / config["entrypoint"]
+        validate_file(entrypoint)
+        os.chmod(entrypoint, 0o700)
+        verify_sha256(
+            entrypoint,
+            entrypoint_sha256(kind, archive_info),
+            "Client Analyzer entrypoint",
+        )
+        if kind == "python":
+            prepare_python_dependencies(entrypoint, payload, workspace)
+
+        write_completion_record(
+            workspace / "complete",
+            completion_record(kind, architecture, workspace.name, archive_info),
+        )
+        completed = True
+        print(f"Client Analyzer {kind} installed in private workspace: {workspace.name}")
+        print(f"Run the matching support action with workspace ID: {workspace.name}")
+    finally:
+        if not completed and workspace is not None and workspace.exists():
+            shutil.rmtree(workspace)
+
+
+def create_run_directory(workspace):
+    runs = workspace / "runs"
+    try:
+        os.mkdir(runs, 0o700)
+    except FileExistsError:
+        validate_directory(runs)
+    return create_private_directory(runs, "run-")
+
+
+def run(kind, workspace_id):
+    config = CONFIGS[kind]
+    if re.fullmatch(
+        re.escape(config["workspace_prefix"]) + r"[0-9a-f]{16}",
+        workspace_id,
+    ) is None:
+        raise HandoffError("Invalid Client Analyzer workspace ID.")
+
+    validate_state_parent()
+    workspace = STATE_PARENT / workspace_id
+    validate_directory(workspace)
+    payload = workspace / "payload"
+    validate_directory(payload)
+    architecture, archive_info = resolve_architecture(kind)
+
+    completion = workspace / "complete"
+    validate_file(completion, 0o600)
+    if completion.read_text(encoding="utf-8") != completion_record(
+        kind,
+        architecture,
+        workspace_id,
+        archive_info,
+    ):
+        raise HandoffError("Client Analyzer completion record failed validation.")
+
+    entrypoint = payload / config["entrypoint"]
+    validate_file(entrypoint, 0o700)
+    verify_sha256(
+        entrypoint,
+        entrypoint_sha256(kind, archive_info),
+        "Client Analyzer entrypoint",
+    )
+
+    run_directory = create_run_directory(workspace)
+    print(f"Client Analyzer run directory: {run_directory}", flush=True)
+    os.chdir(payload)
+    os.execve(
+        entrypoint,
+        [str(entrypoint), "--bypass-disclaimer", "-d"],
+        private_environment(run_directory, python_action=kind == "python"),
+    )
+
+
+def handle_termination(signal_number, _frame):
+    raise HandoffError(f"Installation interrupted by signal {signal_number}.")
+
+
+def main(arguments):
+    if not arguments:
+        raise HandoffError("Missing Client Analyzer action.")
+    command = arguments[0]
+    if command in ("install-binary", "install-python"):
+        if len(arguments) != 1:
+            raise HandoffError("Install actions do not accept parameters.")
+        install(command[len("install-"):])
+        return
+    if command in ("run-binary", "run-python"):
+        if len(arguments) != 2:
+            raise HandoffError("Pass exactly one workspace ID from the installer.")
+        run(command[len("run-"):], arguments[1])
+        return
+    raise HandoffError(f"Unknown Client Analyzer action: {command}")
+
+
+def cli():
+    os.umask(0o077)
+    signal.signal(signal.SIGHUP, handle_termination)
+    signal.signal(signal.SIGTERM, handle_termination)
+    try:
+        main(sys.argv[1:])
+    except HandoffError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except (OSError, ValueError) as error:
+        print(f"ERROR: Client Analyzer action failed: {error}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(cli())

--- a/linux/LiveResponse/ClientAnalyzer/tests/test_minimal_client_analyzer_handoff.py
+++ b/linux/LiveResponse/ClientAnalyzer/tests/test_minimal_client_analyzer_handoff.py
@@ -1,0 +1,448 @@
+import contextlib
+import copy
+import hashlib
+import importlib.util
+import io
+import os
+import re
+import signal
+import stat
+import subprocess
+import tempfile
+import types
+import unittest
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+from unittest import mock
+
+
+CLIENT_ANALYZER_DIR = Path(__file__).resolve().parents[1]
+ACTION_PATH = CLIENT_ANALYZER_DIR / "client_analyzer_handoff.py"
+SPEC = importlib.util.spec_from_file_location("client_analyzer_handoff", ACTION_PATH)
+ACTION = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ACTION)
+
+BINARY_URL = "https://go.microsoft.com/fwlink/?linkid=2336125"
+BINARY_SHA256 = "5f906591d33d675f14d73d5b658a796cec7480b023b18d45c5d687713a4d4fbb"
+BINARY_HASHES = {
+    "amd64": {
+        "machine": "x86_64",
+        "inner_name": "SupportToolLinuxamd64Binary.zip",
+        "inner_sha256": "a500c00fe0dc2bb5b23ec9c771fd40694d111fa78d095d6ff77e4f0b36a23903",
+        "entry_sha256": "b6b21fbc12b6d37be331a5e27a9741b43d35876645e02b26c8cafc4e623ed5e1",
+    },
+    "arm64": {
+        "machine": "aarch64",
+        "inner_name": "SupportToolLinuxarm64Binary.zip",
+        "inner_sha256": "ba8cc0c9766f5c937a90db00af6ed936ecdbfbba88049a383df814203af5066a",
+        "entry_sha256": "a3b60a11eea093f9ec7b9bd7ea86a0e8bbc6f481116311dd678d69def49b5169",
+    },
+}
+PYTHON_URL = "https://go.microsoft.com/fwlink/?linkid=2336046"
+PYTHON_SHA256 = "0b7c350a1c19e049416b1c8fb7ed857569ddcc32fb90453a3fccd083487c0b4e"
+PYTHON_ENTRY_SHA256 = (
+    "00a03ca9b9f9c6d985ef48f8bcaae5cd08b37af551a452d005847d612fb67ffe"
+)
+WRAPPERS = {
+    "InstallXMDEClientAnalyzer.sh": "install-binary",
+    "InstallXMDEPythonClientAnalyzer.sh": "install-python",
+    "MDESupportTool.sh": "run-binary",
+    "MDEPythonSupportTool.sh": "run-python",
+}
+
+
+def sha256_bytes(content):
+    return hashlib.sha256(content).hexdigest()
+
+
+def add_zip_file(archive, name, content, mode=0o600, file_type=stat.S_IFREG):
+    info = zipfile.ZipInfo(name)
+    info.create_system = 3
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = (file_type | mode) << 16
+    archive.writestr(info, content)
+
+
+def binary_entrypoint():
+    return b"#!/bin/sh\nexit 0\n"
+
+
+def python_entrypoint(setup_exit_code=0):
+    return f"#!/bin/sh\nexit {setup_exit_code}\n".encode("utf-8")
+
+
+def python_user_site_entrypoint():
+    return b"""#!/bin/sh
+user_base="$PWD/.deps"
+site_dir=$(PYTHONUSERBASE="$user_base" python3 -c 'import site; print(site.getusersitepackages())')
+mkdir -p "$site_dir"
+printf 'VALUE = 1\\n' > "$site_dir/workspace_dependency.py"
+PYTHONUSERBASE="$user_base" python3 -c 'import workspace_dependency'
+"""
+
+
+def create_binary_archive(path, architecture):
+    entrypoint = binary_entrypoint()
+    inner_buffer = io.BytesIO()
+    with zipfile.ZipFile(inner_buffer, "w") as inner_archive:
+        add_zip_file(inner_archive, "MDESupportTool", entrypoint, mode=0o700)
+    inner_content = inner_buffer.getvalue()
+    with zipfile.ZipFile(path, "w") as outer_archive:
+        add_zip_file(
+            outer_archive,
+            BINARY_HASHES[architecture]["inner_name"],
+            inner_content,
+        )
+    return {
+        "outer_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "inner_sha256": sha256_bytes(inner_content),
+        "entry_sha256": sha256_bytes(entrypoint),
+    }
+
+
+def create_python_archive(path, entrypoint=None):
+    entrypoint = entrypoint if entrypoint is not None else python_entrypoint()
+    with zipfile.ZipFile(path, "w") as archive:
+        add_zip_file(archive, "mde_support_tool.sh", entrypoint, mode=0o700)
+    return {
+        "outer_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "entry_sha256": sha256_bytes(entrypoint),
+    }
+
+
+class HandoffTestCase(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.state_parent = self.root / "state"
+        self.state_parent.mkdir(mode=0o700)
+        self.original_state_parent = ACTION.STATE_PARENT
+        self.original_configs = copy.deepcopy(ACTION.CONFIGS)
+        self.original_umask = os.umask(0o077)
+        ACTION.STATE_PARENT = self.state_parent
+        self.machine_patcher = mock.patch.object(
+            ACTION.platform,
+            "machine",
+            return_value="x86_64",
+        )
+        self.machine_patcher.start()
+
+    def tearDown(self):
+        self.machine_patcher.stop()
+        ACTION.STATE_PARENT = self.original_state_parent
+        ACTION.CONFIGS.clear()
+        ACTION.CONFIGS.update(self.original_configs)
+        os.umask(self.original_umask)
+        self.temporary_directory.cleanup()
+
+    def configure_binary(self, archive, architecture):
+        hashes = create_binary_archive(archive, architecture)
+        config = ACTION.CONFIGS["binary"]
+        config["download_url"] = str(archive)
+        config["outer_sha256"] = hashes["outer_sha256"]
+        config["archives"][architecture]["inner_sha256"] = hashes["inner_sha256"]
+        config["archives"][architecture]["entry_sha256"] = hashes["entry_sha256"]
+        return hashes
+
+    def configure_python(self, archive, entrypoint=None):
+        hashes = create_python_archive(archive, entrypoint)
+        config = ACTION.CONFIGS["python"]
+        config["download_url"] = str(archive)
+        config["outer_sha256"] = hashes["outer_sha256"]
+        config["entry_sha256"] = hashes["entry_sha256"]
+        return hashes
+
+    def copy_download(self, _url, destination):
+        source = Path(ACTION.CONFIGS[self.active_kind]["download_url"])
+        shutil_copy(source, destination)
+
+    def install(self, kind):
+        self.active_kind = kind
+        output = io.StringIO()
+        with mock.patch.object(ACTION, "download_file", side_effect=self.copy_download):
+            with contextlib.redirect_stdout(output):
+                ACTION.install(kind)
+        prefix = ACTION.CONFIGS[kind]["workspace_prefix"]
+        match = re.search(
+            rf"workspace ID: ({re.escape(prefix)}[0-9a-f]{{16}})",
+            output.getvalue(),
+        )
+        self.assertIsNotNone(match, output.getvalue())
+        return match.group(1)
+
+    def run_without_exec(self, kind, workspace_id):
+        with mock.patch.object(ACTION.os, "chdir") as change_directory:
+            with mock.patch.object(ACTION.os, "execve") as execute:
+                ACTION.run(kind, workspace_id)
+        execute.assert_called_once()
+        return change_directory, execute.call_args.args
+
+
+def shutil_copy(source, destination):
+    destination.write_bytes(source.read_bytes())
+    destination.chmod(0o600)
+
+
+class TestSourceAndWrappers(unittest.TestCase):
+    def test_scripts_remove_legacy_paths(self):
+        paths = [
+            ACTION_PATH,
+            *(CLIENT_ANALYZER_DIR / name for name in WRAPPERS),
+        ]
+        for path in paths:
+            with self.subTest(path=path.name):
+                self.assertNotIn(
+                    "/tmp/XMDEClientAnalyzer",
+                    path.read_text(encoding="utf-8"),
+                )
+
+    def test_wrappers_dispatch_to_package_local_helper(self):
+        for name, command in WRAPPERS.items():
+            with self.subTest(wrapper=name):
+                source = (CLIENT_ANALYZER_DIR / name).read_text(encoding="utf-8")
+                self.assertLessEqual(len(source.splitlines()), 16)
+                self.assertIn("client_analyzer_handoff.py", source)
+                self.assertIn(command, source)
+
+    def test_helper_pins_current_artifacts(self):
+        source = ACTION_PATH.read_text(encoding="utf-8")
+        self.assertIn(BINARY_URL, source)
+        self.assertIn(BINARY_SHA256, source)
+        self.assertIn(PYTHON_URL, source)
+        self.assertIn(PYTHON_SHA256, source)
+        for values in BINARY_HASHES.values():
+            self.assertIn(values["inner_sha256"], source)
+            self.assertIn(values["entry_sha256"], source)
+
+    def test_wrappers_pass_only_fixed_mode_and_user_arguments(self):
+        with tempfile.TemporaryDirectory() as directory:
+            package = Path(directory)
+            capture = package / "arguments.txt"
+            helper = package / "client_analyzer_handoff.py"
+            helper.write_text(
+                "import os, sys\n"
+                "open(os.environ['CAPTURE_FILE'], 'w').write('\\n'.join(sys.argv[1:]))\n",
+                encoding="utf-8",
+            )
+            for name, command in WRAPPERS.items():
+                wrapper = package / name
+                wrapper.write_text(
+                    (CLIENT_ANALYZER_DIR / name).read_text(encoding="utf-8"),
+                    encoding="utf-8",
+                )
+                arguments = ["workspace-token"] if command.startswith("run-") else []
+                result = subprocess.run(
+                    ["/bin/sh", str(wrapper), *arguments],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env={**os.environ, "CAPTURE_FILE": str(capture)},
+                    timeout=120,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(
+                    capture.read_text(encoding="utf-8").splitlines(),
+                    [command, *arguments],
+                )
+
+
+class TestInstallerAndRunner(HandoffTestCase):
+    def test_binary_amd64_and_arm64(self):
+        for architecture, machine in (("amd64", "x86_64"), ("arm64", "aarch64")):
+            with self.subTest(architecture=architecture):
+                archive = self.root / f"{architecture}.zip"
+                self.configure_binary(archive, architecture)
+                with mock.patch.object(ACTION.platform, "machine", return_value=machine):
+                    workspace_id = self.install("binary")
+                    _, execute_arguments = self.run_without_exec(
+                        "binary",
+                        workspace_id,
+                    )
+                entrypoint, arguments, environment = execute_arguments
+                self.assertEqual(
+                    arguments,
+                    [str(entrypoint), "--bypass-disclaimer", "-d"],
+                )
+                self.assertRegex(environment["TMPDIR"], r"/runs/run-[0-9a-f]{16}$")
+
+    def test_python_setup_and_run(self):
+        archive = self.root / "python.zip"
+        self.configure_python(archive)
+        workspace_id = self.install("python")
+        _, execute_arguments = self.run_without_exec("python", workspace_id)
+        entrypoint, arguments, environment = execute_arguments
+        self.assertEqual(arguments, [str(entrypoint), "--bypass-disclaimer", "-d"])
+        self.assertEqual(environment["PYTHONDONTWRITEBYTECODE"], "1")
+
+    def test_python_setup_ignores_python_no_user_site(self):
+        archive = self.root / "python-user-site.zip"
+        self.configure_python(archive, python_user_site_entrypoint())
+        with mock.patch.dict(os.environ, {"PYTHONNOUSERSITE": "1"}):
+            self.install("python")
+
+    def test_digest_failure_removes_workspace(self):
+        archive = self.root / "binary.zip"
+        self.configure_binary(archive, "amd64")
+        ACTION.CONFIGS["binary"]["outer_sha256"] = "0" * 64
+        self.active_kind = "binary"
+        with mock.patch.object(ACTION, "download_file", side_effect=self.copy_download):
+            with self.assertRaisesRegex(ACTION.HandoffError, "integrity verification"):
+                ACTION.install("binary")
+        self.assertEqual(list(self.state_parent.iterdir()), [])
+
+    def test_setup_failure_removes_workspace(self):
+        archive = self.root / "python.zip"
+        self.configure_python(archive, python_entrypoint(7))
+        self.active_kind = "python"
+        with mock.patch.object(ACTION, "download_file", side_effect=self.copy_download):
+            with self.assertRaisesRegex(ACTION.HandoffError, "exit code 7"):
+                ACTION.install("python")
+        self.assertEqual(list(self.state_parent.iterdir()), [])
+
+    def test_termination_removes_workspace(self):
+        previous_handler = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, ACTION.handle_termination)
+        self.active_kind = "binary"
+        try:
+            with mock.patch.object(
+                ACTION,
+                "download_file",
+                side_effect=lambda *_args: os.kill(os.getpid(), signal.SIGTERM),
+            ):
+                with self.assertRaisesRegex(ACTION.HandoffError, "interrupted"):
+                    ACTION.install("binary")
+            self.assertEqual(list(self.state_parent.iterdir()), [])
+        finally:
+            signal.signal(signal.SIGTERM, previous_handler)
+
+    def test_invalid_token_is_rejected(self):
+        with self.assertRaisesRegex(ACTION.HandoffError, "Invalid"):
+            ACTION.run("binary", "../unexpected")
+
+    def test_completion_record_tampering_is_rejected(self):
+        archive = self.root / "binary.zip"
+        self.configure_binary(archive, "amd64")
+        workspace_id = self.install("binary")
+        completion = self.state_parent / workspace_id / "complete"
+        completion.write_text("invalid\n", encoding="utf-8")
+        completion.chmod(0o600)
+        with self.assertRaisesRegex(ACTION.HandoffError, "completion record"):
+            ACTION.run("binary", workspace_id)
+
+    def test_entrypoint_tampering_is_rejected(self):
+        archive = self.root / "binary.zip"
+        self.configure_binary(archive, "amd64")
+        workspace_id = self.install("binary")
+        entrypoint = self.state_parent / workspace_id / "payload/MDESupportTool"
+        entrypoint.write_bytes(entrypoint.read_bytes() + b"\n")
+        with self.assertRaisesRegex(ACTION.HandoffError, "integrity verification"):
+            ACTION.run("binary", workspace_id)
+
+
+class TestDownloadCommand(HandoffTestCase):
+    def test_curl_is_https_only_and_bounded(self):
+        captured = {}
+
+        def fake_run(arguments, check, **_kwargs):
+            captured["arguments"] = arguments
+            output = Path(arguments[arguments.index("--output") + 1])
+            output.write_bytes(b"content")
+            output.chmod(0o600)
+            return types.SimpleNamespace(returncode=0)
+
+        with mock.patch.object(ACTION.subprocess, "run", side_effect=fake_run):
+            ACTION.download_file("https://example.invalid/archive.zip", self.root / "a")
+
+        arguments = captured["arguments"]
+        for required in (
+            "-q",
+            "--fail",
+            "--location",
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "--max-filesize",
+            "67108864",
+        ):
+            self.assertIn(required, arguments)
+
+
+def audit_archive(archive):
+    names = set()
+    total = 0
+    for info in archive.infolist():
+        name = info.filename
+        trimmed = name[:-1] if name.endswith("/") else name
+        parts = trimmed.split("/")
+        if (
+            not trimmed
+            or name.startswith("/")
+            or "\\" in name
+            or PurePosixPath(name).is_absolute()
+            or any(part in ("", ".", "..") for part in parts)
+        ):
+            raise AssertionError(f"Unsafe archive path: {name}")
+        normalized = "/".join(parts)
+        if normalized in names:
+            raise AssertionError(f"Duplicate archive path: {normalized}")
+        names.add(normalized)
+        file_type = stat.S_IFMT(info.external_attr >> 16)
+        allowed = (0, stat.S_IFDIR) if info.is_dir() else (0, stat.S_IFREG)
+        if file_type not in allowed:
+            raise AssertionError(f"Link or special archive entry: {normalized}")
+        total += info.file_size
+    if len(names) > 1024 or total > 128 * 1024 * 1024:
+        raise AssertionError("Archive exceeds reviewed limits.")
+
+
+@unittest.skipUnless(
+    os.environ.get("RUN_NETWORK_INTEGRITY_TESTS") == "1",
+    "Set RUN_NETWORK_INTEGRITY_TESTS=1 to verify published artifacts.",
+)
+class TestPublishedArtifactIntegrity(unittest.TestCase):
+    def download(self, url):
+        request = urllib.request.Request(
+            url,
+            headers={"User-Agent": "mdatp-xplat-client-analyzer-test"},
+        )
+        with urllib.request.urlopen(request, timeout=120) as response:
+            content = response.read(64 * 1024 * 1024 + 1)
+        self.assertLessEqual(len(content), 64 * 1024 * 1024)
+        return content
+
+    def test_binary_artifact(self):
+        content = self.download(BINARY_URL)
+        self.assertEqual(sha256_bytes(content), BINARY_SHA256)
+        with zipfile.ZipFile(io.BytesIO(content), "r") as outer_archive:
+            audit_archive(outer_archive)
+            for architecture, expected in BINARY_HASHES.items():
+                with self.subTest(architecture=architecture):
+                    inner_content = outer_archive.read(expected["inner_name"])
+                    self.assertEqual(
+                        sha256_bytes(inner_content),
+                        expected["inner_sha256"],
+                    )
+                    with zipfile.ZipFile(
+                        io.BytesIO(inner_content),
+                        "r",
+                    ) as inner_archive:
+                        audit_archive(inner_archive)
+                        self.assertEqual(
+                            sha256_bytes(inner_archive.read("MDESupportTool")),
+                            expected["entry_sha256"],
+                        )
+
+    def test_python_artifact(self):
+        content = self.download(PYTHON_URL)
+        self.assertEqual(sha256_bytes(content), PYTHON_SHA256)
+        with zipfile.ZipFile(io.BytesIO(content), "r") as archive:
+            audit_archive(archive)
+            self.assertEqual(
+                sha256_bytes(archive.read("mde_support_tool.sh")),
+                PYTHON_ENTRY_SHA256,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/linux/LiveResponse/README.md
+++ b/linux/LiveResponse/README.md
@@ -4,4 +4,4 @@ This is a collection of scripts for Live Response sessions on Linux machines.
 
 ## Client Analyzer
 
-These help install and run the client analyzer on a Linux machine during a live response sessions. For complete directions of how to use these scripts refer to [Microsoft Learn: Run the client analyzer on Linux](https://learn.microsoft.com/en-us/defender-endpoint/run-analyzer-linux).
+These actions install and run Client Analyzer through a private verified workspace. Keep the complete `ClientAnalyzer` directory together so the action wrappers can load their package-local handoff helper. See [Client Analyzer](ClientAnalyzer/README.md) and [Microsoft Learn: Run the client analyzer on Linux](https://learn.microsoft.com/en-us/defender-endpoint/run-analyzer-linux).


### PR DESCRIPTION
## Summary

- harden Client Analyzer workspace handling
- pass one opaque workspace token between separate install and run actions
- fail closed on binary, architecture-specific, Python, and entrypoint digest mismatches
- publish one exact completion record only after installation succeeds
- revalidate workspace ownership, permissions, link counts, completion state, and entrypoint integrity before execution
- use fixed noninteractive diagnostic arguments
- clean incomplete workspaces after failures or normal termination signals

## Problem

The Linux Live Response Client Analyzer workflow is susceptible to attacks.

The scripts also referenced legacy artifact URLs, hashes, and a binary archive layout that no longer matched the current published package.

## Design

### Private handoff

- create a random owner-only workspace under `/var/tmp`
- print only the workspace basename after installation completes
- accept exactly one type-specific workspace token in the runner
- keep binary and Python installations separate

### Integrity

- use current pinned Microsoft artifact hashes
- select and verify amd64 or arm64 inner binary archives
- verify the entrypoint after extraction and again before execution
- audit the current published ZIP member paths, file types, sizes, and entrypoint hashes in the network integrity tests

### Completion and execution

- write a `0600` completion record only after download, verification, extraction, and Python setup succeed
- validate workspace and payload ownership and `0700` permissions
- require regular single-link completion and entrypoint files
- create a private run directory and set `TMPDIR`
- remove loader and Python environment overrides
- execute fixed `--bypass-disclaimer -d` arguments

## Behavior Change

The complete `ClientAnalyzer` directory must remain together because the four existing shell action names dispatch through `client_analyzer_handoff.py`.

1. Run the binary or Python installer without parameters.
2. Copy the printed workspace ID.
3. Pass only that ID to the matching runner.

The runners no longer accept arbitrary Analyzer arguments.

## Testing

- focused suite: 16 tests, 14 passed with 2 opt-in network tests skipped
- published-artifact integrity run: all 16 tests passed
- focused suite passed in 10 consecutive iterations
- amd64, arm64, and Python install and run paths are covered
- checksum, completion-record, entrypoint-tampering, invalid-token, setup-failure, and termination cleanup cases are covered
- Python compilation, shell syntax, ShellCheck, diff checks, and added-comment audit passed
- real binary and Python installers completed against the current published artifacts
- full staged code review and independent security review completed

## Accepted Review Finding

The README lists `mktemp`, `sha256sum`, and `stat` even though those operations are implemented by the Python helper, and it does not explicitly list the required `python3` runtime. The action wrappers make the dependency visible, but the prerequisites list should be corrected in a follow-up.
